### PR TITLE
UI : traduction d'éléments jugés suffisamment stables

### DIFF
--- a/src/components/DocsFooter.tsx
+++ b/src/components/DocsFooter.tsx
@@ -80,7 +80,7 @@ function FooterLink({
         />
         <span>
           <span className="block no-underline text-sm tracking-wide text-secondary dark:text-secondary-dark uppercase font-bold group-focus:text-link dark:group-focus:text-link-dark group-focus:text-opacity-100">
-            {type}
+            {type === 'Next' ? 'Suivant' : 'Précédent'}
           </span>
           <span className="block text-lg group-hover:underline">{title}</span>
         </span>

--- a/src/components/Layout/Feedback.tsx
+++ b/src/components/Layout/Feedback.tsx
@@ -63,11 +63,11 @@ function SendFeedback({onSubmit}: {onSubmit: () => void}) {
   return (
     <div className="max-w-xs w-80 lg:w-auto py-3 shadow-lg rounded-lg m-4 bg-wash dark:bg-gray-95 px-4 flex">
       <p className="w-full font-bold text-primary dark:text-primary-dark text-lg mr-4">
-        {isSubmitted ? 'Thank you for your feedback!' : 'Is this page useful?'}
+        {isSubmitted ? 'Merci pour votre retour !' : 'Cette page est utile ?'}
       </p>
       {!isSubmitted && (
         <button
-          aria-label="Yes"
+          aria-label="Oui"
           className="bg-secondary-button dark:bg-secondary-button-dark rounded-lg text-primary dark:text-primary-dark px-3 mr-2"
           onClick={() => {
             setIsSubmitted(true);
@@ -79,7 +79,7 @@ function SendFeedback({onSubmit}: {onSubmit: () => void}) {
       )}
       {!isSubmitted && (
         <button
-          aria-label="No"
+          aria-label="Non"
           className="bg-secondary-button dark:bg-secondary-button-dark rounded-lg text-primary dark:text-primary-dark px-3"
           onClick={() => {
             setIsSubmitted(true);

--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -286,7 +286,7 @@ export function Footer() {
         </div>
         <div className="flex flex-col">
           <FooterLink href="/learn" isHeader={true}>
-            Learn React
+            Apprendre React
           </FooterLink>
           <FooterLink href="/learn/">Quick Start</FooterLink>
           <FooterLink href="/learn/installation">Installation</FooterLink>
@@ -301,14 +301,14 @@ export function Footer() {
         </div>
         <div className="flex flex-col">
           <FooterLink href="/reference/react" isHeader={true}>
-            API Reference
+            Référence de l’API
           </FooterLink>
           <FooterLink href="/reference/react">React APIs</FooterLink>
           <FooterLink href="/reference/react-dom">React DOM APIs</FooterLink>
         </div>
         <div className="md:col-start-2 xl:col-start-4 flex flex-col">
           <FooterLink href="/community" isHeader={true}>
-            Community
+            Communauté
           </FooterLink>
           <FooterLink href="https://github.com/facebook/react/blob/main/CODE_OF_CONDUCT.md">
             Code of Conduct
@@ -322,7 +322,7 @@ export function Footer() {
           </FooterLink>
         </div>
         <div className="flex flex-col">
-          <FooterLink isHeader={true}>More</FooterLink>
+          <FooterLink isHeader={true}>Plus</FooterLink>
           <FooterLink href="/blog">Blog</FooterLink>
           <FooterLink href="https://reactnative.dev/">React Native</FooterLink>
           <FooterLink href="https://opensource.facebook.com/legal/privacy">

--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -153,7 +153,7 @@ export function Page({children, toc, routeTree, meta, section}: PageProps) {
                     <>
                       <div className="flex flex-col items-center m-4 p-4">
                         <p className="font-bold text-primary dark:text-primary-dark text-lg mb-4">
-                          How do you like these docs?
+                          Comment trouvez-vous ces docs ?
                         </p>
                         <div>
                           <ButtonLink
@@ -162,7 +162,7 @@ export function Page({children, toc, routeTree, meta, section}: PageProps) {
                             type="primary"
                             size="md"
                             target="_blank">
-                            Take our survey!
+                            Dites-nous tout !
                             <IconNavArrow
                               displayDirection="right"
                               className="inline ml-1"

--- a/src/components/MDX/MDXComponents.tsx
+++ b/src/components/MDX/MDXComponents.tsx
@@ -173,7 +173,7 @@ function YouWillLearn({
   children: any;
   isChapter?: boolean;
 }) {
-  let title = isChapter ? 'In this chapter' : 'You will learn';
+  let title = isChapter ? 'Dans ce chapitre' : 'Vous allez apprendre';
   return <SimpleCallout title={title}>{children}</SimpleCallout>;
 }
 

--- a/src/components/MDX/Sandpack/CustomPreset.tsx
+++ b/src/components/MDX/Sandpack/CustomPreset.tsx
@@ -119,7 +119,7 @@ const SandboxShell = memo(function SandboxShell({
                   className="inline mr-1.5 text-xl"
                   displayDirection={isExpanded ? 'up' : 'down'}
                 />
-                {isExpanded ? 'Show less' : 'Show more'}
+                {isExpanded ? 'Voir moins' : 'Voir plus'}
               </span>
             </button>
           )}

--- a/src/components/MDX/Sandpack/DownloadButton.tsx
+++ b/src/components/MDX/Sandpack/DownloadButton.tsx
@@ -98,9 +98,9 @@ ${css}
     <button
       className="text-sm text-primary dark:text-primary-dark inline-flex items-center hover:text-link duration-100 ease-in transition mx-1"
       onClick={downloadHTML}
-      title="Download Sandbox"
+      title="Télécharger la sandbox"
       type="button">
-      <IconDownload className="inline mr-1" /> Download
+      <IconDownload className="inline mr-1" /> Télécharger
     </button>
   );
 }

--- a/src/components/MDX/Sandpack/OpenInCodeSandboxButton.tsx
+++ b/src/components/MDX/Sandpack/OpenInCodeSandboxButton.tsx
@@ -9,7 +9,7 @@ export const OpenInCodeSandboxButton = () => {
   return (
     <UnstyledOpenInCodeSandboxButton
       className="text-sm text-primary dark:text-primary-dark inline-flex items-center hover:text-link duration-100 ease-in transition mx-1 ml-2 md:ml-1"
-      title="Open in CodeSandbox">
+      title="Ouvrir dans CodeSandbox">
       <IconNewPage
         className="inline ml-1 mr-1 relative top-[1px]"
         width="1em"

--- a/src/components/MDX/Sandpack/ResetButton.tsx
+++ b/src/components/MDX/Sandpack/ResetButton.tsx
@@ -13,9 +13,9 @@ export function ResetButton({onReset}: ResetButtonProps) {
     <button
       className="text-sm text-primary dark:text-primary-dark inline-flex items-center hover:text-link duration-100 ease-in transition mx-1"
       onClick={onReset}
-      title="Reset Sandbox"
+      title="Réinitialiser la sandbox"
       type="button">
-      <IconRestart className="inline ml-1 mr-1 relative" /> Reset
+      <IconRestart className="inline ml-1 mr-1 relative" /> Réinitialiser
     </button>
   );
 }


### PR DESCRIPTION
La structure des docs devrait encore pas mal changer, et l'équipe noyau nous demande de ne pas trop traduire la nav (sidebar, footer…) pour le moment.

Toutefois, j'estime que certains éléments ne devraient plus bouger de façon significative, voire plus du tout, et méritent donc une traduction d'entrée de jeu, notamment pour lisser la perception de langue au sein d'une même page de doc :

- Les en-têtes principaux de structure de nav (déjà traduits en en-tête pour #449), ici dans le footer
- Le widget de feedback positif/négatif d'utilité de page (en bas à gauche en desktop)
- Les éléments de fin de page (appel à réponse au sondage sur les nouvelles docs, liens Précédent / Suivant)
- Les éléments d'UI des sandboxes (boutons Télécharger, Réinitialiser, Fork, bascules Voir plus / moins)
- Les mini-TOC en début de page ("Dans ce chapitre" / "Vous allez apprendre")