### PR TITLE
Partial translation of community contents

### DIFF
--- a/TRANSLATORS.md
+++ b/TRANSLATORS.md
@@ -116,6 +116,14 @@ Voici la liste par ordre alphabétique (prénom, nom). **🙏🏻 Mille mercis �
           <li><a href="https://fr.react.dev/reference/react/createRef"><code>createRef</code></a></li>
           <li><a href="https://fr.react.dev/reference/react/isValidElement"><code>isValidElement</code></a></li>
           <li><a href="https://fr.react.dev/reference/react/PureComponent"><code>PureComponent</code></a></li>
+          <li><a href="https://fr.react.dev/community">Communauté</a> (accueil chapitre)</li>
+          <li><a href="https://fr.react.dev/community/conferences">Conférences React</a> (partiel)</li>
+          <li><a href="https://fr.react.dev/community/meetups">Meetups React</a> (partiel)</li>
+          <li><a href="https://fr.react.dev/community/videos">Vidéos React</a> (partiel)</li>
+          <li><a href="https://fr.react.dev/community/team">Rencontrez l’équipe</a></li>
+          <li><a href="https://fr.react.dev/community/docs-contributors">Contributeurs aux docs</a></li>
+          <li><a href="https://fr.react.dev/community/acknowledgements">Remerciements</a></li>
+          <li><a href="https://fr.react.dev/blog">Blog</a> (accueil)</li>
         </ul>
       </td>
     </tr>
@@ -1145,4 +1153,4 @@ Voici la liste par ordre alphabétique (prénom, nom). **🙏🏻 Mille mercis �
 
 ---
 
-_Dernière mise à jour : 05/07/2023_
+_Dernière mise à jour : 30/08/2023_

--- a/src/content/blog/index.md
+++ b/src/content/blog/index.md
@@ -1,10 +1,10 @@
 ---
-title: React Blog
+title: Blog React
 ---
 
 <Intro>
 
-This blog is the official source for the updates from the React team. Anything important, including release notes or deprecation notices, will be posted here first. You can also follow the [@reactjs](https://twitter.com/reactjs) account on Twitter, but you won’t miss anything essential if you only read this blog.
+Ce blog est la source officielle des mises à jour par l'équipe React.  Toute annonce importante, y compris les notes de versions et les avertissements de dépréciation, sera faite ici en premier.  Vous pouvez aussi suivre le compte [@reactjs](https://twitter.com/reactjs) sur Twitter, mais vous êtes sûr·e de ne rien rater d'important si vous ne lisez que ce blog.
 
 </Intro>
 
@@ -62,14 +62,14 @@ The React team is excited to share a few updates:
 
 ---
 
-### All release notes {/*all-release-notes*/}
+### Toutes les notes de versions {/*all-release-notes*/}
 
-Not every React release deserves its own blog post, but you can find a detailed changelog for every release in the [`CHANGELOG.md`](https://github.com/facebook/react/blob/main/CHANGELOG.md) file in the React repository, as well as on the [Releases](https://github.com/facebook/react/releases) page.
+Toute les versions de React ne méritent pas forcément leur propre billet de blog, mais vous pouvez trouver un *changelog* détaillé pour chaque version dans le fichier [`CHANGELOG.md`](https://github.com/facebook/react/blob/main/CHANGELOG.md) du dépôt React, ainsi que dans sa page [Releases](https://github.com/facebook/react/releases).
 
 ---
 
-### Older posts {/*older-posts*/}
+### Billets plus anciens {/*older-posts*/}
 
-See the [older posts.](https://reactjs.org/blog/all.html)
+Consultez les [anciens billets](https://legacy.reactjs.org/blog/all.html/).
 
 <div className="h-12"></div>

--- a/src/content/community/acknowledgements.md
+++ b/src/content/community/acknowledgements.md
@@ -1,16 +1,16 @@
 ---
-title: Acknowledgements
+title: Remerciements
 ---
 
 <Intro>
 
-React was originally created by [Jordan Walke.](https://github.com/jordwalke) Today, React has a [dedicated full-time team working on it](/community/team), as well as over a thousand [open source contributors.](https://github.com/facebook/react/blob/main/AUTHORS)
+React a été créé à l'origine par [Jordan Walke](https://github.com/jordwalke). Aujourd'hui, React dispose d'une [équipe dédiée travaillant dessus à temps plein](/community/team), ainsi que de plus d'un millier de [contributeurs en logiciel libre](https://github.com/facebook/react/blob/main/AUTHORS).
 
 </Intro>
 
-## Past contributors {/*past-contributors*/}
+## Contributeurs passés {/*past-contributors*/}
 
-We'd like to recognize a few people who have made significant contributions to React and its documentation in the past and have helped maintain them over the years:
+Nous aimerions remercier particulièrement certaines personnes ayant effectué des contributions significatives à React et à sa documentation par le passé, et qui ont aidé à le maintenir au fil des ans :
 
 * [Almero Steyn](https://github.com/AlmeroSteyn)
 * [Andreas Svensson](https://github.com/syranide)
@@ -51,15 +51,15 @@ We'd like to recognize a few people who have made significant contributions to R
 * [Tim Yung](https://github.com/yungsters)
 * [Xuan Huang](https://github.com/huxpro)
 
-This list is not exhaustive.
+Cette liste n'est pas exhaustive.
 
-We'd like to give special thanks to [Tom Occhino](https://github.com/tomocchino) and [Adam Wolff](https://github.com/wolffiex) for their guidance and support over the years. We are also thankful to all the volunteers who [translated React into other languages.](https://translations.reactjs.org/)
+Nous aimerions remercier tout particulièrement [Tom Occhino](https://github.com/tomocchino) et [Adam Wolff](https://github.com/wolffiex) pour leur encadrement et leur soutien au fil des ans. Nous sommes aussi reconnaissants à tou·te·s les bénévoles qui [traduisent React dans d'autres langues](https://translations.react.dev/) (vous trouverez le [détail pour le français ici](https://github.com/reactjs/fr.react.dev/blob/main/TRANSLATORS.md)).
 
-## Additional Thanks {/*additional-thanks*/}
+## Encore quelques mercis {/*additional-thanks*/}
 
-Additionally, we're grateful to:
+Pour finir, nous aimerions remercier :
 
-* [Jeff Barczewski](https://github.com/jeffbski) for allowing us to use the `react` package name on npm
-* [Christopher Aue](https://christopheraue.net/) for letting us use the reactjs.com domain name and the [@reactjs](https://twitter.com/reactjs) username on Twitter
-* [ProjectMoon](https://github.com/ProjectMoon) for letting us use the [flux](https://www.npmjs.com/package/flux) package name on npm
-* Shane Anderson for allowing us to use the [react](https://github.com/react) org on GitHub
+* [Jeff Barczewski](https://github.com/jeffbski) pour nous avoir permis d'utiliser le nom de module `react` sur npm
+* [Christopher Aue](https://christopheraue.net/) pour nous avoir permis d'utiliser le nom de domaine reactjs.com et le nom de compte Twitter [@reactjs](https://twitter.com/reactjs)
+* [ProjectMoon](https://github.com/ProjectMoon) pour nous avoir permis d'utiliser le nom de module [flux](https://www.npmjs.com/package/flux) sur npm
+* Shane Anderson pour nous avoir permis d'utiliser l'organisation [react](https://github.com/react) sur GitHub

--- a/src/content/community/conferences.md
+++ b/src/content/community/conferences.md
@@ -1,146 +1,146 @@
 ---
-title: React Conferences
+title: Conférences React
 ---
 
 <Intro>
 
-Do you know of a local React.js conference? Add it here! (Please keep the list chronological)
+Vous connaissez une conférence React.js locale ? Ajoutez-la ! (Merci de conserver un ordre chronologique dans chaque liste.)
 
 </Intro>
 
-## Upcoming Conferences {/*upcoming-conferences*/}
+## Conférences à venir {/*upcoming-conferences*/}
 
 ### React Rally 2023 🐙 {/*react-rally-2023*/}
 August 17 & 18, 2023. Salt Lake City, UT, USA
 
-[Website](https://www.reactrally.com/) - [Twitter](https://twitter.com/ReactRally) - [Instagram](https://www.instagram.com/reactrally/)
+[Site web](https://www.reactrally.com/) - [Twitter](https://twitter.com/ReactRally) - [Instagram](https://www.instagram.com/reactrally/)
 
 ### React Native EU 2023 {/*react-native-eu-2023*/}
 September 7 & 8, 2023. Wrocław, Poland
 
-[Website](https://react-native.eu) - [Twitter](https://twitter.com/react_native_eu) - [Facebook](https://www.facebook.com/reactnativeeu)
+[Site web](https://react-native.eu) - [Twitter](https://twitter.com/react_native_eu) - [Facebook](https://www.facebook.com/reactnativeeu)
 
 
 ### React India 2023 {/*react-india-2023*/}
 October 5 - 7, 2023. In-person in Goa, India (hybrid event) + Oct 3 2023 - remote day
 
-[Website](https://www.reactindia.io) - [Twitter](https://twitter.com/react_india) - [Facebook](https://www.facebook.com/ReactJSIndia) - [Youtube](https://www.youtube.com/channel/UCaFbHCBkPvVv1bWs_jwYt3w)
+[Site web](https://www.reactindia.io) - [Twitter](https://twitter.com/react_india) - [Facebook](https://www.facebook.com/ReactJSIndia) - [Youtube](https://www.youtube.com/channel/UCaFbHCBkPvVv1bWs_jwYt3w)
 
 ### React Advanced 2023 {/*react-advanced-2023*/}
 October 20 & 23, 2023. In-person in London, UK + remote first interactivity (hybrid event)
 
-[Website](https://www.reactadvanced.com/) - [Twitter](https://twitter.com/ReactAdvanced) - [Facebook](https://www.facebook.com/ReactAdvanced) - [Videos](https://portal.gitnation.org/events/react-advanced-conference-2023)
+[Site web](https://www.reactadvanced.com/) - [Twitter](https://twitter.com/ReactAdvanced) - [Facebook](https://www.facebook.com/ReactAdvanced) - [Vidéos](https://portal.gitnation.org/events/react-advanced-conference-2023)
 
 ### React Summit US 2023 {/*react-summit-us-2023*/}
 November 13 & 15, 2023. In-person in New York, US + remote first interactivity (hybrid event)
 
-[Website](https://reactsummit.us) - [Twitter](https://twitter.com/reactsummit) - [Facebook](https://www.facebook.com/reactamsterdam) - [Videos](https://portal.gitnation.org/events/react-summit-us-2023)
+[Site web](https://reactsummit.us) - [Twitter](https://twitter.com/reactsummit) - [Facebook](https://www.facebook.com/reactamsterdam) - [Vidéos](https://portal.gitnation.org/events/react-summit-us-2023)
 
 ### React Day Berlin 2023 {/*react-day-berlin-2023*/}
 December 8 & 12, 2023. In-person in Berlin, Germany + remote first interactivity (hybrid event)
 
-[Website](https://reactday.berlin) - [Twitter](https://twitter.com/reactdayberlin) - [Facebook](https://www.facebook.com/reactdayberlin/) - [Videos](https://portal.gitnation.org/events/react-day-berlin-2023)
+[Site web](https://reactday.berlin) - [Twitter](https://twitter.com/reactdayberlin) - [Facebook](https://www.facebook.com/reactdayberlin/) - [Vidéos](https://portal.gitnation.org/events/react-day-berlin-2023)
 
-## Past Conferences {/*past-conferences*/}
+## Conférences passées {/*past-conferences*/}
 
 ### React Nexus 2023 {/*react-nexus-2023*/}
 July 07 & 08, 2023. Bangalore, India (In-person event)
 
-[Website](https://reactnexus.com/) - [Twitter](https://twitter.com/ReactNexus) - [Linkedin](https://www.linkedin.com/company/react-nexus) - [YouTube](https://www.youtube.com/reactify_in)
+[Site web](https://reactnexus.com/) - [Twitter](https://twitter.com/ReactNexus) - [Linkedin](https://www.linkedin.com/company/react-nexus) - [YouTube](https://www.youtube.com/reactify_in)
 
 ### ReactNext 2023 {/*reactnext-2023*/}
 June 27th, 2023. Tel Aviv, Israel
 
-[Website](https://www.react-next.com/) - [Facebook](https://www.facebook.com/ReactNextConf) - [Youtube](https://www.youtube.com/@ReactNext)
+[Site web](https://www.react-next.com/) - [Facebook](https://www.facebook.com/ReactNextConf) - [Youtube](https://www.youtube.com/@ReactNext)
 
 ### React Norway 2023 {/*react-norway-2023*/}
 June 16th, 2023. Larvik, Norway
 
-[Website](https://reactnorway.com/) - [Twitter](https://twitter.com/ReactNorway/) - [Facebook](https://www.facebook.com/reactdaynorway/)
+[Site web](https://reactnorway.com/) - [Twitter](https://twitter.com/ReactNorway/) - [Facebook](https://www.facebook.com/reactdaynorway/)
 
 ### React Summit 2023 {/*react-summit-2023*/}
 June 2 & 6, 2023. In-person in Amsterdam, Netherlands + remote first interactivity (hybrid event)
 
-[Website](https://reactsummit.com) - [Twitter](https://twitter.com/reactsummit) - [Facebook](https://www.facebook.com/reactamsterdam) - [Videos](https://portal.gitnation.org/events/react-summit-2023)
+[Site web](https://reactsummit.com) - [Twitter](https://twitter.com/reactsummit) - [Facebook](https://www.facebook.com/reactamsterdam) - [Vidéos](https://portal.gitnation.org/events/react-summit-2023)
 
 ### Render(ATL) 2023 🍑 {/*renderatl-2023-*/}
 May 31 - June 2, 2023. Atlanta, GA, USA
 
-[Website](https://renderatl.com) - [Discord](https://www.renderatl.com/discord) - [Twitter](https://twitter.com/renderATL) - [Instagram](https://www.instagram.com/renderatl/) - [Facebook](https://www.facebook.com/renderatl/) - [LinkedIn](https://www.linkedin.com/company/renderatl) - [Podcast](https://www.renderatl.com/culture-and-code#/)
+[Site web](https://renderatl.com) - [Discord](https://www.renderatl.com/discord) - [Twitter](https://twitter.com/renderATL) - [Instagram](https://www.instagram.com/renderatl/) - [Facebook](https://www.facebook.com/renderatl/) - [LinkedIn](https://www.linkedin.com/company/renderatl) - [Podcast](https://www.renderatl.com/culture-and-code#/)
 
 ### Chain React 2023 {/*chain-react-2023*/}
 May 17 - 19, 2023. Portland, OR, USA
 
-[Website](https://chainreactconf.com/) - [Twitter](https://twitter.com/ChainReactConf) - [Facebook](https://www.facebook.com/ChainReactConf/) - [Youtube](https://www.youtube.com/channel/UCwpSzVt7QpLDbCnPXqR97-g/playlists)
+[Site web](https://chainreactconf.com/) - [Twitter](https://twitter.com/ChainReactConf) - [Facebook](https://www.facebook.com/ChainReactConf/) - [Youtube](https://www.youtube.com/channel/UCwpSzVt7QpLDbCnPXqR97-g/playlists)
 
 ### App.js Conf 2023 {/*appjs-conf-2023*/}
 May 10 - 12, 2023. In-person in Kraków, Poland + remote
 
-[Website](https://appjs.co) - [Twitter](https://twitter.com/appjsconf)
+[Site web](https://appjs.co) - [Twitter](https://twitter.com/appjsconf)
 
 ### RemixConf 2023 {/*remixconf-2023*/}
 May, 2023. Salt Lake City, UT
 
-[Website](https://remix.run/conf/2023) - [Twitter](https://twitter.com/remix_run)
+[Site web](https://remix.run/conf/2023) - [Twitter](https://twitter.com/remix_run)
 
 ### Reactathon 2023 {/*reactathon-2023*/}
 May 2 - 3, 2023. San Francisco, CA, USA
 
-[Website](https://reactathon.com) - [Twitter](https://twitter.com/reactathon) - [YouTube](https://www.youtube.com/realworldreact)
+[Site web](https://reactathon.com) - [Twitter](https://twitter.com/reactathon) - [YouTube](https://www.youtube.com/realworldreact)
 
 ### React Miami 2023 {/*react-miami-2023*/}
 April 20 - 21, 2023. Miami, FL, USA
 
-[Website](https://www.reactmiami.com/) - [Twitter](https://twitter.com/ReactMiamiConf)
+[Site web](https://www.reactmiami.com/) - [Twitter](https://twitter.com/ReactMiamiConf)
 
 ### React Day Berlin 2022 {/*react-day-berlin-2022*/}
 December 2, 2022. In-person in Berlin, Germany + remote (hybrid event)
 
-[Website](https://reactday.berlin) - [Twitter](https://twitter.com/reactdayberlin) - [Facebook](https://www.facebook.com/reactdayberlin/) - [Videos](https://www.youtube.com/c/ReactConferences)
+[Site web](https://reactday.berlin) - [Twitter](https://twitter.com/reactdayberlin) - [Facebook](https://www.facebook.com/reactdayberlin/) - [Vidéos](https://www.youtube.com/c/ReactConferences)
 
 ### React Global Online Summit 22.2 by Geekle {/*react-global-online-summit-222-by-geekle*/}
 November 8 - 9, 2022 - Online Summit
 
-[Website](https://events.geekle.us/react3/) - [LinkedIn](https://www.linkedin.com/posts/geekle-us_event-react-reactjs-activity-6964904611207864320-gpDx?utm_source=share&utm_medium=member_desktop)
+[Site web](https://events.geekle.us/react3/) - [LinkedIn](https://www.linkedin.com/posts/geekle-us_event-react-reactjs-activity-6964904611207864320-gpDx?utm_source=share&utm_medium=member_desktop)
 
 ### Remix Conf Europe 2022 {/*remix-conf-europe-2022*/}
 November 18, 2022, 7am PST / 10am EST / 4pm CET - remote event
 
-[Website](https://remixconf.eu/) - [Twitter](https://twitter.com/remixconfeu) - [Videos](https://portal.gitnation.org/events/remix-conf-europe-2022)
+[Site web](https://remixconf.eu/) - [Twitter](https://twitter.com/remixconfeu) - [Vidéos](https://portal.gitnation.org/events/remix-conf-europe-2022)
 
 ### React Advanced 2022 {/*react-advanced-2022*/}
 October 21 & 25, 2022. In-person in London, UK + remote (hybrid event)
 
-[Website](https://www.reactadvanced.com/) - [Twitter](https://twitter.com/ReactAdvanced) - [Facebook](https://www.facebook.com/ReactAdvanced) - [Videos](https://portal.gitnation.org/events/react-advanced-conference-2022)
+[Site web](https://www.reactadvanced.com/) - [Twitter](https://twitter.com/ReactAdvanced) - [Facebook](https://www.facebook.com/ReactAdvanced) - [Vidéos](https://portal.gitnation.org/events/react-advanced-conference-2022)
 
 ### ReactJS Day 2022 {/*reactjs-day-2022*/}
 October 21, 2022 in Verona, Italy
 
-[Website](https://2022.reactjsday.it/) - [Twitter](https://twitter.com/reactjsday) - [LinkedIn](https://www.linkedin.com/company/grusp/) - [Facebook](https://www.facebook.com/reactjsday/) - [Videos](https://www.youtube.com/c/grusp)
+[Site web](https://2022.reactjsday.it/) - [Twitter](https://twitter.com/reactjsday) - [LinkedIn](https://www.linkedin.com/company/grusp/) - [Facebook](https://www.facebook.com/reactjsday/) - [Vidéos](https://www.youtube.com/c/grusp)
 
 ### React Brussels 2022 {/*react-brussels-2022*/}
 October 14, 2022. In-person in Brussels, Belgium + remote (hybrid event)
 
-[Website](https://www.react.brussels/) - [Twitter](https://twitter.com/BrusselsReact) - [LinkedIn](https://www.linkedin.com/events/6938421827153088512/) - [Facebook](https://www.facebook.com/events/1289080838167252/) - [Videos](https://www.youtube.com/channel/UCvES7lMpnx-t934qGxD4w4g)
+[Site web](https://www.react.brussels/) - [Twitter](https://twitter.com/BrusselsReact) - [LinkedIn](https://www.linkedin.com/events/6938421827153088512/) - [Facebook](https://www.facebook.com/events/1289080838167252/) - [Vidéos](https://www.youtube.com/channel/UCvES7lMpnx-t934qGxD4w4g)
 
 ### React Alicante 2022 {/*react-alicante-2022*/}
 September 29 - October 1, 2022. In-person in Alicante, Spain + remote (hybrid event)
 
-[Website](https://reactalicante.es/) - [Twitter](https://twitter.com/reactalicante) - [Facebook](https://www.facebook.com/ReactAlicante) - [Videos](https://www.youtube.com/channel/UCaSdUaITU1Cz6PvC97A7e0w)
+[Site web](https://reactalicante.es/) - [Twitter](https://twitter.com/reactalicante) - [Facebook](https://www.facebook.com/ReactAlicante) - [Vidéos](https://www.youtube.com/channel/UCaSdUaITU1Cz6PvC97A7e0w)
 ### React India 2022 {/*react-india-2022*/}
 September 22 - 24, 2022. In-person in Goa, India + remote (hybrid event)
 
-[Website](https://www.reactindia.io) - [Twitter](https://twitter.com/react_india) - [Facebook](https://www.facebook.com/ReactJSIndia) - [Videos](https://www.youtube.com/channel/UCaFbHCBkPvVv1bWs_jwYt3w)
+[Site web](https://www.reactindia.io) - [Twitter](https://twitter.com/react_india) - [Facebook](https://www.facebook.com/ReactJSIndia) - [Vidéos](https://www.youtube.com/channel/UCaFbHCBkPvVv1bWs_jwYt3w)
 
 ### React Finland 2022 {/*react-finland-2022*/}
 September 12 - 16, 2022. In-person in Helsinki, Finland
 
-[Website](https://react-finland.fi/) - [Twitter](https://twitter.com/ReactFinland) - [Schedule](https://react-finland.fi/schedule/) - [Speakers](https://react-finland.fi/speakers/)
+[Site web](https://react-finland.fi/) - [Twitter](https://twitter.com/ReactFinland) - [Schedule](https://react-finland.fi/schedule/) - [Speakers](https://react-finland.fi/speakers/)
 
 ### React Native EU 2022: Powered by callstack {/*react-native-eu-2022-powered-by-callstack*/}
 September 1-2, 2022 - Remote event
 
-[Website](https://www.react-native.eu/?utm_campaign=React_Native_EU&utm_source=referral&utm_content=reactjs_community_conferences) -
+[Site web](https://www.react-native.eu/?utm_campaign=React_Native_EU&utm_source=referral&utm_content=reactjs_community_conferences) -
 [Twitter](https://twitter.com/react_native_eu) -
 [Linkedin](https://www.linkedin.com/showcase/react-native-eu) -
 [Facebook](https://www.facebook.com/reactnativeeu/) -
@@ -149,580 +149,580 @@ September 1-2, 2022 - Remote event
 ### ReactNext 2022 {/*reactnext-2022*/}
 June 28, 2022. Tel-Aviv, Israel
 
-[Website](https://react-next.com) - [Twitter](https://twitter.com/ReactNext) - [Videos](https://www.youtube.com/c/ReactNext)
+[Site web](https://react-next.com) - [Twitter](https://twitter.com/ReactNext) - [Vidéos](https://www.youtube.com/c/ReactNext)
 
 ### React Norway 2022 {/*react-norway-2022*/}
 June 24, 2022. In-person at Farris Bad Hotel in Larvik, Norway and online (hybrid event).
 
-[Website](https://reactnorway.com/) - [Twitter](https://twitter.com/ReactNorway)
+[Site web](https://reactnorway.com/) - [Twitter](https://twitter.com/ReactNorway)
 
 ### React Summit 2022 {/*react-summit-2022*/}
 June 17 & 21, 2022. In-person in Amsterdam, Netherlands + remote first interactivity (hybrid event)
 
-[Website](https://reactsummit.com) - [Twitter](https://twitter.com/reactsummit) - [Facebook](https://www.facebook.com/reactamsterdam) - [Videos](https://portal.gitnation.org/events/react-summit-2022)
+[Site web](https://reactsummit.com) - [Twitter](https://twitter.com/reactsummit) - [Facebook](https://www.facebook.com/reactamsterdam) - [Vidéos](https://portal.gitnation.org/events/react-summit-2022)
 
 ### App.js Conf 2022 {/*appjs-conf-2022*/}
 June 8 - 10, 2022. In-person in Kraków, Poland + remote
 
-[Website](https://appjs.co) - [Twitter](https://twitter.com/appjsconf)
+[Site web](https://appjs.co) - [Twitter](https://twitter.com/appjsconf)
 
 ### React Day Bangalore 2022 {/*react-day-bangalore-2022*/}
 June 8 - 9, 2022.  Remote
 
-[Website](https://reactday.in/) - [Twitter](https://twitter.com/ReactDayIn) - [Linkedin](https://www.linkedin.com/company/react-day/) - [YouTube](https://www.youtube.com/reactify_in)
+[Site web](https://reactday.in/) - [Twitter](https://twitter.com/ReactDayIn) - [Linkedin](https://www.linkedin.com/company/react-day/) - [YouTube](https://www.youtube.com/reactify_in)
 
 ### render(ATL) 2022 🍑 {/*renderatl-2022-*/}
 June 1 - 4, 2022. Atlanta, GA, USA
 
-[Website](https://renderatl.com) - [Discord](https://www.renderatl.com/discord) - [Twitter](https://twitter.com/renderATL) - [Instagram](https://www.instagram.com/renderatl/) - [Facebook](https://www.facebook.com/renderatl/) - [LinkedIn](https://www.linkedin.com/company/renderatl) - [Podcast](https://www.renderatl.com/culture-and-code#/)
+[Site web](https://renderatl.com) - [Discord](https://www.renderatl.com/discord) - [Twitter](https://twitter.com/renderATL) - [Instagram](https://www.instagram.com/renderatl/) - [Facebook](https://www.facebook.com/renderatl/) - [LinkedIn](https://www.linkedin.com/company/renderatl) - [Podcast](https://www.renderatl.com/culture-and-code#/)
 
 ### RemixConf 2022 {/*remixconf-2022*/}
 May 24 - 25, 2022. Salt Lake City, UT
 
-[Website](https://remix.run/conf/2022) - [Twitter](https://twitter.com/remix_run) - [YouTube](https://www.youtube.com/playlist?list=PLXoynULbYuEC36XutMMWEuTu9uuh171wx)
+[Site web](https://remix.run/conf/2022) - [Twitter](https://twitter.com/remix_run) - [YouTube](https://www.youtube.com/playlist?list=PLXoynULbYuEC36XutMMWEuTu9uuh171wx)
 
 ### Reactathon 2022 {/*reactathon-2022*/}
 May 3 - 5, 2022. Berkeley, CA
 
-[Website](https://reactathon.com) - [Twitter](https://twitter.com/reactathon) -[YouTube](https://www.youtube.com/watch?v=-YG5cljNXIA)
+[Site web](https://reactathon.com) - [Twitter](https://twitter.com/reactathon) -[YouTube](https://www.youtube.com/watch?v=-YG5cljNXIA)
 
 ### React Global Online Summit 2022 by Geekle {/*react-global-online-summit-2022-by-geekle*/}
 April 20 - 21, 2022 - Online Summit
 
-[Website](https://events.geekle.us/react2/) - [LinkedIn](https://www.linkedin.com/events/reactglobalonlinesummit-226887417664541614081/)
+[Site web](https://events.geekle.us/react2/) - [LinkedIn](https://www.linkedin.com/events/reactglobalonlinesummit-226887417664541614081/)
 
 ### React Miami 2022 🌴 {/*react-miami-2022-*/}
 April 18 - 19, 2022. Miami, Florida
-[Website](https://www.reactmiami.com/)
+[Site web](https://www.reactmiami.com/)
 
 ### React Live 2022 {/*react-live-2022*/}
 April 1, 2022. Amsterdam, The Netherlands
 
-[Website](https://www.reactlive.nl/) - [Twitter](https://twitter.com/reactlivenl)
+[Site web](https://www.reactlive.nl/) - [Twitter](https://twitter.com/reactlivenl)
 
 ### AgentConf 2022 {/*agentconf-2022*/}
 
 January 27 - 30, 2022. In-person in Dornbirn and Lech Austria
 
-[Website](https://agent.sh/) - [Twitter](https://twitter.com/AgentConf) - [Instagram](https://www.instagram.com/teamagent/)
+[Site web](https://agent.sh/) - [Twitter](https://twitter.com/AgentConf) - [Instagram](https://www.instagram.com/teamagent/)
 
 ### React Conf 2021 {/*react-conf-2021*/}
 December 8, 2021 - remote event (replay event on December 9)
 
-[Website](https://conf.reactjs.org/)
+[Site web](https://conf.reactjs.org/)
 
 ### ReactEurope 2021 {/*reacteurope-2021*/}
 December 9-10, 2021 - remote event
 
-[Videos](https://www.youtube.com/c/ReacteuropeOrgConf)
+[Vidéos](https://www.youtube.com/c/ReacteuropeOrgConf)
 
 ### ReactNext 2021 {/*reactnext-2021*/}
 December 15, 2021. Tel-Aviv, Israel
 
-[Website](https://react-next.com) - [Twitter](https://twitter.com/ReactNext) - [Videos](https://www.youtube.com/channel/UC3BT8hh3yTTYxbLQy_wbk2w)
+[Site web](https://react-next.com) - [Twitter](https://twitter.com/ReactNext) - [Vidéos](https://www.youtube.com/channel/UC3BT8hh3yTTYxbLQy_wbk2w)
 
 ### React India 2021 {/*react-india-2021*/}
 November 12-13, 2021 - remote event
 
-[Website](https://www.reactindia.io) - [Twitter](https://twitter.com/react_india) - [Facebook](https://www.facebook.com/ReactJSIndia/) - [LinkedIn](https://www.linkedin.com/showcase/14545585) - [YouTube](https://www.youtube.com/channel/UCaFbHCBkPvVv1bWs_jwYt3w/videos)
+[Site web](https://www.reactindia.io) - [Twitter](https://twitter.com/react_india) - [Facebook](https://www.facebook.com/ReactJSIndia/) - [LinkedIn](https://www.linkedin.com/showcase/14545585) - [YouTube](https://www.youtube.com/channel/UCaFbHCBkPvVv1bWs_jwYt3w/videos)
 
 ### React Global by Geekle {/*react-global-by-geekle*/}
 November 3-4, 2021 - remote event
 
-[Website](https://geekle.us/react) - [LinkedIn](https://www.linkedin.com/events/javascriptglobalsummit6721691514176720896/) - [YouTube](https://www.youtube.com/watch?v=0HhWIvPhbu0)
+[Site web](https://geekle.us/react) - [LinkedIn](https://www.linkedin.com/events/javascriptglobalsummit6721691514176720896/) - [YouTube](https://www.youtube.com/watch?v=0HhWIvPhbu0)
 
 ### React Advanced 2021 {/*react-advanced-2021*/}
 October 22-23, 2021. In-person in London, UK + remote (hybrid event)
 
-[Website](https://reactadvanced.com) - [Twitter](https://twitter.com/reactadvanced) - [Facebook](https://www.facebook.com/ReactAdvanced) - [Videos](https://youtube.com/c/ReactConferences)
+[Site web](https://reactadvanced.com) - [Twitter](https://twitter.com/reactadvanced) - [Facebook](https://www.facebook.com/ReactAdvanced) - [Vidéos](https://youtube.com/c/ReactConferences)
 
 ### React Conf Brasil 2021 {/*react-conf-brasil-2021*/}
 October 16, 2021 - remote event
 
-[Website](http://reactconf.com.br) - [Twitter](https://twitter.com/reactconfbr) - [Slack](https://react.now.sh) - [Facebook](https://facebook.com/reactconf) - [Instagram](https://instagram.com/reactconfbr) - [YouTube](https://www.youtube.com/channel/UCJL5eorStQfC0x1iiWhvqPA/videos)
+[Site web](http://reactconf.com.br) - [Twitter](https://twitter.com/reactconfbr) - [Slack](https://react.now.sh) - [Facebook](https://facebook.com/reactconf) - [Instagram](https://instagram.com/reactconfbr) - [YouTube](https://www.youtube.com/channel/UCJL5eorStQfC0x1iiWhvqPA/videos)
 
 ### React Brussels 2021 {/*react-brussels-2021*/}
 October 15, 2021 - remote event
 
-[Website](https://www.react.brussels/) - [Twitter](https://twitter.com/BrusselsReact) - [LinkedIn](https://www.linkedin.com/events/6805708233819336704/)
+[Site web](https://www.react.brussels/) - [Twitter](https://twitter.com/BrusselsReact) - [LinkedIn](https://www.linkedin.com/events/6805708233819336704/)
 
 ### render(ATL) 2021 {/*renderatl-2021*/}
 September 13-15, 2021. Atlanta, GA, USA
 
-[Website](https://renderatl.com) - [Twitter](https://twitter.com/renderATL) - [Instagram](https://www.instagram.com/renderatl/) - [Facebook](https://www.facebook.com/renderatl/) - [LinkedIn](https://www.linkedin.com/company/renderatl)
+[Site web](https://renderatl.com) - [Twitter](https://twitter.com/renderATL) - [Instagram](https://www.instagram.com/renderatl/) - [Facebook](https://www.facebook.com/renderatl/) - [LinkedIn](https://www.linkedin.com/company/renderatl)
 
 ### React Native EU 2021 {/*react-native-eu-2021*/}
 September 1-2, 2021 - remote event
 
-[Website](https://www.react-native.eu/) - [Twitter](https://twitter.com/react_native_eu) - [Facebook](https://www.facebook.com/reactnativeeu/) - [Instagram](https://www.instagram.com/reactnative_eu/)
+[Site web](https://www.react-native.eu/) - [Twitter](https://twitter.com/react_native_eu) - [Facebook](https://www.facebook.com/reactnativeeu/) - [Instagram](https://www.instagram.com/reactnative_eu/)
 
 ### React Finland 2021 {/*react-finland-2021*/}
 August 30 - September 3, 2021 - remote event
 
-[Website](https://react-finland.fi/) - [Twitter](https://twitter.com/ReactFinland) - [LinkedIn](https://www.linkedin.com/company/react-finland/)
+[Site web](https://react-finland.fi/) - [Twitter](https://twitter.com/ReactFinland) - [LinkedIn](https://www.linkedin.com/company/react-finland/)
 
 ### React Case Study Festival 2021 {/*react-case-study-festival-2021*/}
 April 27-28, 2021 - remote event
 
-[Website](https://link.geekle.us/react/offsite) - [LinkedIn](https://www.linkedin.com/events/reactcasestudyfestival6721300943411015680/) - [Facebook](https://www.facebook.com/events/255715435820203)
+[Site web](https://link.geekle.us/react/offsite) - [LinkedIn](https://www.linkedin.com/events/reactcasestudyfestival6721300943411015680/) - [Facebook](https://www.facebook.com/events/255715435820203)
 
 ### React Summit - Remote Edition 2021 {/*react-summit---remote-edition-2021*/}
 April 14-16, 2021, 7am PST / 10am EST / 4pm CEST - remote event
 
-[Website](https://remote.reactsummit.com) - [Twitter](https://twitter.com/reactsummit) - [Facebook](https://www.facebook.com/reactamsterdam) - [Videos](https://portal.gitnation.org/events/react-summit-remote-edition-2021)
+[Site web](https://remote.reactsummit.com) - [Twitter](https://twitter.com/reactsummit) - [Facebook](https://www.facebook.com/reactamsterdam) - [Vidéos](https://portal.gitnation.org/events/react-summit-remote-edition-2021)
 
 ### React fwdays’21 {/*react-fwdays21*/}
 March 27, 2021 - remote event
 
-[Website](https://fwdays.com/en/event/react-fwdays-2021) - [Twitter](https://twitter.com/fwdays) - [Facebook](https://www.facebook.com/events/1133828147054286) - [LinkedIn](https://www.linkedin.com/events/reactfwdays-21onlineconference6758046347334582273) - [Meetup](https://www.meetup.com/ru-RU/Fwdays/events/275764431/)
+[Site web](https://fwdays.com/en/event/react-fwdays-2021) - [Twitter](https://twitter.com/fwdays) - [Facebook](https://www.facebook.com/events/1133828147054286) - [LinkedIn](https://www.linkedin.com/events/reactfwdays-21onlineconference6758046347334582273) - [Meetup](https://www.meetup.com/ru-RU/Fwdays/events/275764431/)
 
 ### React Next 2020 {/*react-next-2020*/}
 December 1-2, 2020 - remote event
 
-[Website](https://react-next.com/) - [Twitter](https://twitter.com/reactnext) - [Facebook](https://www.facebook.com/ReactNext2016/)
+[Site web](https://react-next.com/) - [Twitter](https://twitter.com/reactnext) - [Facebook](https://www.facebook.com/ReactNext2016/)
 
 ### React Conf Brasil 2020 {/*react-conf-brasil-2020*/}
 November 21, 2020 - remote event
 
-[Website](https://reactconf.com.br/) - [Twitter](https://twitter.com/reactconfbr) - [Slack](https://react.now.sh/)
+[Site web](https://reactconf.com.br/) - [Twitter](https://twitter.com/reactconfbr) - [Slack](https://react.now.sh/)
 
 ### React Summit 2020 {/*react-summit-2020*/}
 October 15-16, 2020, 7am PST / 10am EST / 4pm CEST - remote event
 
-[Website](https://reactsummit.com) - [Twitter](https://twitter.com/reactsummit) - [Facebook](https://www.facebook.com/reactamsterdam) - [Videos](https://youtube.com/c/ReactConferences)
+[Site web](https://reactsummit.com) - [Twitter](https://twitter.com/reactsummit) - [Facebook](https://www.facebook.com/reactamsterdam) - [Vidéos](https://youtube.com/c/ReactConferences)
 
 ### React Native EU 2020 {/*react-native-eu-2020*/}
 September 3-4, 2020 - remote event
 
-[Website](https://www.react-native.eu/) - [Twitter](https://twitter.com/react_native_eu) - [Facebook](https://www.facebook.com/reactnativeeu/) - [YouTube](https://www.youtube.com/watch?v=m0GfmlGFh3E&list=PLZ3MwD-soTTHy9_88QPLF8DEJkvoB5Tl-) - [Instagram](https://www.instagram.com/reactnative_eu/)
+[Site web](https://www.react-native.eu/) - [Twitter](https://twitter.com/react_native_eu) - [Facebook](https://www.facebook.com/reactnativeeu/) - [YouTube](https://www.youtube.com/watch?v=m0GfmlGFh3E&list=PLZ3MwD-soTTHy9_88QPLF8DEJkvoB5Tl-) - [Instagram](https://www.instagram.com/reactnative_eu/)
 
 ### ReactEurope 2020 {/*reacteurope-2020*/}
 May 14-15, 2020 in Paris, France
 
-[Videos](https://www.youtube.com/c/ReacteuropeOrgConf)
+[Vidéos](https://www.youtube.com/c/ReacteuropeOrgConf)
 
 ### Byteconf React 2020 {/*byteconf-react-2020*/}
 May 1, 2020. Streamed online on YouTube.
 
-[Website](https://www.bytesized.xyz) - [Twitter](https://twitter.com/bytesizedcode) - [YouTube](https://www.youtube.com/channel/UC046lFvJZhiwSRWsoH8SFjg)
+[Site web](https://www.bytesized.xyz) - [Twitter](https://twitter.com/bytesizedcode) - [YouTube](https://www.youtube.com/channel/UC046lFvJZhiwSRWsoH8SFjg)
 
 ### React Summit - Remote Edition 2020 {/*react-summit---remote-edition-2020*/}
 3pm CEST time, April 17, 2020 - remote event
 
-[Website](https://remote.reactsummit.com) - [Twitter](https://twitter.com/reactsummit) - [Facebook](https://www.facebook.com/reactamsterdam) - [Videos](https://youtube.com/c/ReactConferences)
+[Site web](https://remote.reactsummit.com) - [Twitter](https://twitter.com/reactsummit) - [Facebook](https://www.facebook.com/reactamsterdam) - [Vidéos](https://youtube.com/c/ReactConferences)
 
 ### Reactathon 2020 {/*reactathon-2020*/}
 March 30 - 31, 2020 in San Francisco, CA
 
-[Website](https://www.reactathon.com) - [Twitter](https://twitter.com/reactathon) - [Facebook](https://www.facebook.com/events/575942819854160/)
+[Site web](https://www.reactathon.com) - [Twitter](https://twitter.com/reactathon) - [Facebook](https://www.facebook.com/events/575942819854160/)
 
 ### ReactConf AU 2020 {/*reactconf-au-2020*/}
 February 27 & 28, 2020 in Sydney, Australia
 
-[Website](https://reactconfau.com/) - [Twitter](https://twitter.com/reactconfau) - [Facebook](https://www.facebook.com/reactconfau) - [Instagram](https://www.instagram.com/reactconfau/)
+[Site web](https://reactconfau.com/) - [Twitter](https://twitter.com/reactconfau) - [Facebook](https://www.facebook.com/reactconfau) - [Instagram](https://www.instagram.com/reactconfau/)
 
 ### React Barcamp Cologne 2020 {/*react-barcamp-cologne-2020*/}
 February 1-2, 2020 in Cologne, Germany
 
-[Website](https://react-barcamp.de/) - [Twitter](https://twitter.com/ReactBarcamp) - [Facebook](https://www.facebook.com/reactbarcamp)
+[Site web](https://react-barcamp.de/) - [Twitter](https://twitter.com/ReactBarcamp) - [Facebook](https://www.facebook.com/reactbarcamp)
 
 ### React Day Berlin 2019 {/*react-day-berlin-2019*/}
 December 6, 2019 in Berlin, Germany
 
-[Website](https://reactday.berlin) - [Twitter](https://twitter.com/reactdayberlin) - [Facebook](https://www.facebook.com/reactdayberlin/) - [Videos](https://www.youtube.com/reactdayberlin)
+[Site web](https://reactday.berlin) - [Twitter](https://twitter.com/reactdayberlin) - [Facebook](https://www.facebook.com/reactdayberlin/) - [Vidéos](https://www.youtube.com/reactdayberlin)
 
 ### React Summit 2019 {/*react-summit-2019*/}
 November 30, 2019 in Lagos, Nigeria
 
-[Website](https://reactsummit2019.splashthat.com) -[Twitter](https://twitter.com/react_summit)
+[Site web](https://reactsummit2019.splashthat.com) -[Twitter](https://twitter.com/react_summit)
 
 ### React Conf Brasil 2019 {/*react-conf-brasil-2019*/}
 October 19, 2019 in São Paulo, BR
 
-[Website](https://reactconf.com.br/) - [Twitter](https://twitter.com/reactconfbr) - [Facebook](https://www.facebook.com/ReactAdvanced) - [Slack](https://react.now.sh/)
+[Site web](https://reactconf.com.br/) - [Twitter](https://twitter.com/reactconfbr) - [Facebook](https://www.facebook.com/ReactAdvanced) - [Slack](https://react.now.sh/)
 
 ### React Advanced 2019 {/*react-advanced-2019*/}
 October 25, 2019 in London, UK
 
-[Website](https://reactadvanced.com) - [Twitter](http://twitter.com/reactadvanced) - [Facebook](https://www.facebook.com/ReactAdvanced) - [Videos](https://youtube.com/c/ReactConferences)
+[Site web](https://reactadvanced.com) - [Twitter](http://twitter.com/reactadvanced) - [Facebook](https://www.facebook.com/ReactAdvanced) - [Vidéos](https://youtube.com/c/ReactConferences)
 
 ### React Conf 2019 {/*react-conf-2019*/}
 October 24-25, 2019 in Henderson, Nevada USA
 
-[Website](https://conf.reactjs.org/) - [Twitter](https://twitter.com/reactjs)
+[Site web](https://conf.reactjs.org/) - [Twitter](https://twitter.com/reactjs)
 
 ### React Alicante 2019 {/*react-alicante-2019*/}
 September 26-28, 2019 in Alicante, Spain
 
-[Website](http://reactalicante.es/) - [Twitter](https://twitter.com/reactalicante) - [Facebook](https://www.facebook.com/ReactAlicante)
+[Site web](http://reactalicante.es/) - [Twitter](https://twitter.com/reactalicante) - [Facebook](https://www.facebook.com/ReactAlicante)
 
 ### React India 2019 {/*react-india-2019*/}
 September 26-28, 2019 in Goa, India
 
-[Website](https://www.reactindia.io/) - [Twitter](https://twitter.com/react_india) - [Facebook](https://www.facebook.com/ReactJSIndia)
+[Site web](https://www.reactindia.io/) - [Twitter](https://twitter.com/react_india) - [Facebook](https://www.facebook.com/ReactJSIndia)
 
 ### React Boston 2019 {/*react-boston-2019*/}
 September 21-22, 2019 in Boston, Massachusetts USA
 
-[Website](https://www.reactboston.com/) - [Twitter](https://twitter.com/reactboston)
+[Site web](https://www.reactboston.com/) - [Twitter](https://twitter.com/reactboston)
 
 ### React Live 2019 {/*react-live-2019*/}
 September 13th, 2019. Amsterdam, The Netherlands
 
-[Website](https://www.reactlive.nl/) - [Twitter](https://twitter.com/reactlivenl)
+[Site web](https://www.reactlive.nl/) - [Twitter](https://twitter.com/reactlivenl)
 
 ### React New York 2019 {/*react-new-york-2019*/}
 September 13th, 2019. New York, USA
 
-[Website](https://reactnewyork.com/) - [Twitter](https://twitter.com/reactnewyork)
+[Site web](https://reactnewyork.com/) - [Twitter](https://twitter.com/reactnewyork)
 
 ### ComponentsConf 2019 {/*componentsconf-2019*/}
 September 6, 2019 in Melbourne, Australia
 
-[Website](https://www.componentsconf.com.au/) - [Twitter](https://twitter.com/componentsconf)
+[Site web](https://www.componentsconf.com.au/) - [Twitter](https://twitter.com/componentsconf)
 
 ### React Native EU 2019 {/*react-native-eu-2019*/}
 September 5-6 in Wrocław, Poland
 
-[Website](https://react-native.eu) - [Twitter](https://twitter.com/react_native_eu) - [Facebook](https://www.facebook.com/reactnativeeu)
+[Site web](https://react-native.eu) - [Twitter](https://twitter.com/react_native_eu) - [Facebook](https://www.facebook.com/reactnativeeu)
 
 ### React Conf Iran 2019 {/*react-conf-iran-2019*/}
 August 29, 2019. Tehran, Iran.
 
-[Website](https://reactconf.ir/) - [Videos](https://www.youtube.com/playlist?list=PL-VNqZFI5Nf-Nsj0rD3CWXGPkH-DI_0VY) - [Highlights](https://github.com/ReactConf/react-conf-highlights)
+[Site web](https://reactconf.ir/) - [Vidéos](https://www.youtube.com/playlist?list=PL-VNqZFI5Nf-Nsj0rD3CWXGPkH-DI_0VY) - [Highlights](https://github.com/ReactConf/react-conf-highlights)
 
 ### React Rally 2019 {/*react-rally-2019*/}
 August 22-23, 2019. Salt Lake City, USA.
 
-[Website](https://www.reactrally.com/) - [Twitter](https://twitter.com/ReactRally) - [Instagram](https://www.instagram.com/reactrally/)
+[Site web](https://www.reactrally.com/) - [Twitter](https://twitter.com/ReactRally) - [Instagram](https://www.instagram.com/reactrally/)
 
 ### Chain React 2019 {/*chain-react-2019*/}
 July 11-12, 2019. Portland, OR, USA.
 
-[Website](https://infinite.red/ChainReactConf)
+[Site web](https://infinite.red/ChainReactConf)
 
 ### React Loop 2019 {/*react-loop-2019*/}
 June 21, 2019 Chicago, Illinois USA
 
-[Website](https://reactloop.com) - [Twitter](https://twitter.com/ReactLoop)
+[Site web](https://reactloop.com) - [Twitter](https://twitter.com/ReactLoop)
 
 ### React Norway 2019 {/*react-norway-2019*/}
 June 12, 2019. Larvik, Norway
 
-[Website](https://reactnorway.com) - [Twitter](https://twitter.com/ReactNorway)
+[Site web](https://reactnorway.com) - [Twitter](https://twitter.com/ReactNorway)
 
 ### ReactNext 2019 {/*reactnext-2019*/}
 June 11, 2019. Tel Aviv, Israel
 
-[Website](https://react-next.com) - [Twitter](https://twitter.com/ReactNext) - [Videos](https://www.youtube.com/channel/UC3BT8hh3yTTYxbLQy_wbk2w)
+[Site web](https://react-next.com) - [Twitter](https://twitter.com/ReactNext) - [Vidéos](https://www.youtube.com/channel/UC3BT8hh3yTTYxbLQy_wbk2w)
 
 ### React Conf Armenia 2019 {/*react-conf-armenia-2019*/}
 May 25, 2019 in Yerevan, Armenia
 
-[Website](https://reactconf.am/) - [Twitter](https://twitter.com/ReactConfAM) - [Facebook](https://www.facebook.com/reactconf.am/) - [YouTube](https://www.youtube.com/c/JavaScriptConferenceArmenia) - [CFP](http://bit.ly/speakReact)
+[Site web](https://reactconf.am/) - [Twitter](https://twitter.com/ReactConfAM) - [Facebook](https://www.facebook.com/reactconf.am/) - [YouTube](https://www.youtube.com/c/JavaScriptConferenceArmenia) - [CFP](http://bit.ly/speakReact)
 
 ### ReactEurope 2019 {/*reacteurope-2019*/}
 May 23-24, 2019 in Paris, France
 
-[Videos](https://www.youtube.com/c/ReacteuropeOrgConf)
+[Vidéos](https://www.youtube.com/c/ReacteuropeOrgConf)
 
 ### React.NotAConf 2019 {/*reactnotaconf-2019*/}
 May 11 in Sofia, Bulgaria
 
-[Website](http://react-not-a-conf.com/) - [Twitter](https://twitter.com/reactnotaconf) - [Facebook](https://www.facebook.com/events/780891358936156)
+[Site web](http://react-not-a-conf.com/) - [Twitter](https://twitter.com/reactnotaconf) - [Facebook](https://www.facebook.com/events/780891358936156)
 
 ### ReactJS Girls Conference {/*reactjs-girls-conference*/}
 May 3, 2019 in London, UK
 
-[Website](https://reactjsgirls.com/) - [Twitter](https://twitter.com/reactjsgirls)
+[Site web](https://reactjsgirls.com/) - [Twitter](https://twitter.com/reactjsgirls)
 
 ### React Finland 2019 {/*react-finland-2019*/}
 April 24-26 in Helsinki, Finland
 
-[Website](https://react-finland.fi/) - [Twitter](https://twitter.com/ReactFinland)
+[Site web](https://react-finland.fi/) - [Twitter](https://twitter.com/ReactFinland)
 
 ### React Amsterdam 2019 {/*react-amsterdam-2019*/}
 April 12, 2019 in Amsterdam, The Netherlands
 
-[Website](https://reactsummit.com) - [Twitter](https://twitter.com/reactsummit) - [Facebook](https://www.facebook.com/reactamsterdam) - [Videos](https://youtube.com/c/ReactConferences)
+[Site web](https://reactsummit.com) - [Twitter](https://twitter.com/reactsummit) - [Facebook](https://www.facebook.com/reactamsterdam) - [Vidéos](https://youtube.com/c/ReactConferences)
 
 ### App.js Conf 2019 {/*appjs-conf-2019*/}
 April 4-5, 2019 in Kraków, Poland
 
-[Website](https://appjs.co) - [Twitter](https://twitter.com/appjsconf)
+[Site web](https://appjs.co) - [Twitter](https://twitter.com/appjsconf)
 
 ### Reactathon 2019 {/*reactathon-2019*/}
 March 30-31, 2019 in San Francisco, USA
 
-[Website](https://www.reactathon.com/) - [Twitter](https://twitter.com/reactathon)
+[Site web](https://www.reactathon.com/) - [Twitter](https://twitter.com/reactathon)
 
 ### React Iran 2019 {/*react-iran-2019*/}
 January 31, 2019 in Tehran, Iran
 
-[Website](http://reactiran.com) - [Instagram](https://www.instagram.com/reactiran/)
+[Site web](http://reactiran.com) - [Instagram](https://www.instagram.com/reactiran/)
 
 ### React Day Berlin 2018 {/*react-day-berlin-2018*/}
 November 30, Berlin, Germany
 
-[Website](https://reactday.berlin) - [Twitter](https://twitter.com/reactdayberlin) - [Facebook](https://www.facebook.com/reactdayberlin/) - [Videos](https://www.youtube.com/channel/UC1EYHmQYBUJjkmL6OtK4rlw)
+[Site web](https://reactday.berlin) - [Twitter](https://twitter.com/reactdayberlin) - [Facebook](https://www.facebook.com/reactdayberlin/) - [Vidéos](https://www.youtube.com/channel/UC1EYHmQYBUJjkmL6OtK4rlw)
 
 ### ReactNext 2018 {/*reactnext-2018*/}
 November 4 in Tel Aviv, Israel
 
-[Website](https://react-next.com) - [Twitter](https://twitter.com/ReactNext) - [Facebook](https://facebook.com/ReactNext2016)
+[Site web](https://react-next.com) - [Twitter](https://twitter.com/ReactNext) - [Facebook](https://facebook.com/ReactNext2016)
 
 ### React Conf 2018 {/*react-conf-2018*/}
 October 25-26 in Henderson, Nevada USA
 
-[Website](https://conf.reactjs.org/)
+[Site web](https://conf.reactjs.org/)
 
 ### React Conf Brasil 2018 {/*react-conf-brasil-2018*/}
 October 20 in Sao Paulo, Brazil
 
-[Website](http://reactconfbr.com.br) - [Twitter](https://twitter.com/reactconfbr) - [Facebook](https://www.facebook.com/reactconf)
+[Site web](http://reactconfbr.com.br) - [Twitter](https://twitter.com/reactconfbr) - [Facebook](https://www.facebook.com/reactconf)
 
 ### ReactJS Day 2018 {/*reactjs-day-2018*/}
 October 5 in Verona, Italy
 
-[Website](http://2018.reactjsday.it) - [Twitter](https://twitter.com/reactjsday)
+[Site web](http://2018.reactjsday.it) - [Twitter](https://twitter.com/reactjsday)
 
 ### React Boston 2018 {/*react-boston-2018*/}
 September 29-30 in Boston, Massachusetts USA
 
-[Website](http://www.reactboston.com/) - [Twitter](https://twitter.com/ReactBoston)
+[Site web](http://www.reactboston.com/) - [Twitter](https://twitter.com/ReactBoston)
 
 ### React Alicante 2018 {/*react-alicante-2018*/}
 September 13-15 in Alicante, Spain
 
-[Website](http://reactalicante.es) - [Twitter](https://twitter.com/ReactAlicante)
+[Site web](http://reactalicante.es) - [Twitter](https://twitter.com/ReactAlicante)
 
 ### React Native EU 2018 {/*react-native-eu-2018*/}
 September 5-6 in Wrocław, Poland
 
-[Website](https://react-native.eu) - [Twitter](https://twitter.com/react_native_eu) - [Facebook](https://www.facebook.com/reactnativeeu)
+[Site web](https://react-native.eu) - [Twitter](https://twitter.com/react_native_eu) - [Facebook](https://www.facebook.com/reactnativeeu)
 
 ### Byteconf React 2018 {/*byteconf-react-2018*/}
 August 31 streamed online, via Twitch
 
-[Website](https://byteconf.com) - [Twitch](https://twitch.tv/byteconf) - [Twitter](https://twitter.com/byteconf)
+[Site web](https://byteconf.com) - [Twitch](https://twitch.tv/byteconf) - [Twitter](https://twitter.com/byteconf)
 
 ### ReactFoo Delhi {/*reactfoo-delhi*/}
 August 18 in Delhi, India
 
-[Website](https://reactfoo.in/2018-delhi/) - [Twitter](https://twitter.com/reactfoo) - [Past talks](https://hasgeek.tv)
+[Site web](https://reactfoo.in/2018-delhi/) - [Twitter](https://twitter.com/reactfoo) - [Past talks](https://hasgeek.tv)
 
 ### React DEV Conf China {/*react-dev-conf-china*/}
 August 18 in Guangzhou, China
 
-[Website](https://react.w3ctech.com)
+[Site web](https://react.w3ctech.com)
 
-### React Rally 2018{/*react-rally-2018*/}
+### React Rally 2018 {/*react-rally-2018*/}
 August 16-17 in Salt Lake City, Utah USA
 
-[Website](http://www.reactrally.com) - [Twitter](https://twitter.com/reactrally)
+[Site web](http://www.reactrally.com) - [Twitter](https://twitter.com/reactrally)
 
 ### Chain React 2018 {/*chain-react-2018*/}
 July 11-13 in Portland, Oregon USA
 
-[Website](https://infinite.red/ChainReactConf) - [Twitter](https://twitter.com/chainreactconf)
+[Site web](https://infinite.red/ChainReactConf) - [Twitter](https://twitter.com/chainreactconf)
 
 ### ReactFoo Mumbai {/*reactfoo-mumbai*/}
 May 26 in Mumbai, India
 
-[Website](https://reactfoo.in/2018-mumbai/) - [Twitter](https://twitter.com/reactfoo) - [Past talks](https://hasgeek.tv)
+[Site web](https://reactfoo.in/2018-mumbai/) - [Twitter](https://twitter.com/reactfoo) - [Past talks](https://hasgeek.tv)
 
 
 ### ReactEurope 2018 {/*reacteurope-2018*/}
 May 17-18 in Paris, France
 
-[Videos](https://www.youtube.com/c/ReacteuropeOrgConf)
+[Vidéos](https://www.youtube.com/c/ReacteuropeOrgConf)
 
 ### React.NotAConf 2018 {/*reactnotaconf-2018*/}
 April 28 in Sofia, Bulgaria
 
-[Website](http://react-not-a-conf.com/) - [Twitter](https://twitter.com/reactnotaconf) - [Facebook](https://www.facebook.com/groups/1614950305478021/)
+[Site web](http://react-not-a-conf.com/) - [Twitter](https://twitter.com/reactnotaconf) - [Facebook](https://www.facebook.com/groups/1614950305478021/)
 
 ### React Finland 2018 {/*react-finland-2018*/}
 April 24-26 in Helsinki, Finland
 
-[Website](https://react-finland.fi/) - [Twitter](https://twitter.com/ReactFinland)
+[Site web](https://react-finland.fi/) - [Twitter](https://twitter.com/ReactFinland)
 
 ### React Amsterdam 2018 {/*react-amsterdam-2018*/}
 April 13 in Amsterdam, The Netherlands
 
-[Website](https://reactsummit.com) - [Twitter](https://twitter.com/reactsummit) - [Facebook](https://www.facebook.com/reactamsterdam)
+[Site web](https://reactsummit.com) - [Twitter](https://twitter.com/reactsummit) - [Facebook](https://www.facebook.com/reactamsterdam)
 
 ### React Native Camp UA 2018 {/*react-native-camp-ua-2018*/}
 March 31 in Kiev, Ukraine
 
-[Website](http://reactnative.com.ua/) - [Twitter](https://twitter.com/reactnativecamp) - [Facebook](https://www.facebook.com/reactnativecamp/)
+[Site web](http://reactnative.com.ua/) - [Twitter](https://twitter.com/reactnativecamp) - [Facebook](https://www.facebook.com/reactnativecamp/)
 
 ### Reactathon 2018 {/*reactathon-2018*/}
 March 20-22 in San Francisco, USA
 
-[Website](https://www.reactathon.com/) - [Twitter](https://twitter.com/reactathon) - [Videos (fundamentals)](https://www.youtube.com/watch?v=knn364bssQU&list=PLRvKvw42Rc7OWK5s-YGGFSmByDzzgC0HP), [Videos (advanced day1)](https://www.youtube.com/watch?v=57hmk4GvJpk&list=PLRvKvw42Rc7N0QpX2Rc5CdrqGuxzwD_0H), [Videos (advanced day2)](https://www.youtube.com/watch?v=1hvQ8p8q0a0&list=PLRvKvw42Rc7Ne46QAjWNWFo1Jf0mQdnIW)
+[Site web](https://www.reactathon.com/) - [Twitter](https://twitter.com/reactathon) - [Videos (fundamentals)](https://www.youtube.com/watch?v=knn364bssQU&list=PLRvKvw42Rc7OWK5s-YGGFSmByDzzgC0HP), [Videos (advanced day1)](https://www.youtube.com/watch?v=57hmk4GvJpk&list=PLRvKvw42Rc7N0QpX2Rc5CdrqGuxzwD_0H), [Videos (advanced day2)](https://www.youtube.com/watch?v=1hvQ8p8q0a0&list=PLRvKvw42Rc7Ne46QAjWNWFo1Jf0mQdnIW)
 
 ### ReactFest 2018 {/*reactfest-2018*/}
 March 8-9 in London, UK
 
-[Website](https://reactfest.uk/) - [Twitter](https://twitter.com/ReactFest) - [Videos](https://www.youtube.com/watch?v=YOCrJ5vRCnw&list=PLRgweB8YtNRt-Sf-A0y446wTJNUaAAmle)
+[Site web](https://reactfest.uk/) - [Twitter](https://twitter.com/ReactFest) - [Vidéos](https://www.youtube.com/watch?v=YOCrJ5vRCnw&list=PLRgweB8YtNRt-Sf-A0y446wTJNUaAAmle)
 
 ### AgentConf 2018 {/*agentconf-2018*/}
 January 25-28 in Dornbirn, Austria
 
-[Website](http://agent.sh/)
+[Site web](http://agent.sh/)
 
 ### ReactFoo Pune {/*reactfoo-pune*/}
 January 19-20, Pune, India
 
-[Website](https://reactfoo.in/2018-pune/) - [Twitter](https://twitter.com/ReactFoo)
+[Site web](https://reactfoo.in/2018-pune/) - [Twitter](https://twitter.com/ReactFoo)
 
 ### React Day Berlin 2017 {/*react-day-berlin-2017*/}
 December 2, Berlin, Germany
 
-[Website](https://reactday.berlin) - [Twitter](https://twitter.com/reactdayberlin) - [Facebook](https://www.facebook.com/reactdayberlin/) - [Videos](https://www.youtube.com/watch?v=UnNLJvHKfSY&list=PL-3BrJ5CiIx5GoXci54-VsrO6GwLhSHEK)
+[Site web](https://reactday.berlin) - [Twitter](https://twitter.com/reactdayberlin) - [Facebook](https://www.facebook.com/reactdayberlin/) - [Vidéos](https://www.youtube.com/watch?v=UnNLJvHKfSY&list=PL-3BrJ5CiIx5GoXci54-VsrO6GwLhSHEK)
 
 ### React Seoul 2017 {/*react-seoul-2017*/}
 November 4 in Seoul, South Korea
 
-[Website](http://seoul.reactjs.kr/en)
+[Site web](http://seoul.reactjs.kr/en)
 
 ### ReactiveConf 2017 {/*reactiveconf-2017*/}
 October 25–27, Bratislava, Slovakia
 
-[Website](https://reactiveconf.com) - [Videos](https://www.youtube.com/watch?v=BOKxSFB2hOE&list=PLa2ZZ09WYepMB-I7AiDjDYR8TjO8uoNjs)
+[Site web](https://reactiveconf.com) - [Vidéos](https://www.youtube.com/watch?v=BOKxSFB2hOE&list=PLa2ZZ09WYepMB-I7AiDjDYR8TjO8uoNjs)
 
 ### React Summit 2017 {/*react-summit-2017*/}
 October 21 in Lagos, Nigeria
 
-[Website](https://reactsummit2017.splashthat.com/) - [Twitter](https://twitter.com/DevCircleLagos/) - [Facebook](https://www.facebook.com/groups/DevCLagos/)
+[Site web](https://reactsummit2017.splashthat.com/) - [Twitter](https://twitter.com/DevCircleLagos/) - [Facebook](https://www.facebook.com/groups/DevCLagos/)
 
 ### State.js Conference 2017 {/*statejs-conference-2017*/}
 October 13 in Stockholm, Sweden
 
-[Website](https://statejs.com/)
+[Site web](https://statejs.com/)
 
 ### React Conf Brasil 2017 {/*react-conf-brasil-2017*/}
 October 7 in Sao Paulo, Brazil
 
-[Website](http://reactconfbr.com.br) - [Twitter](https://twitter.com/reactconfbr) - [Facebook](https://www.facebook.com/reactconf/)
+[Site web](http://reactconfbr.com.br) - [Twitter](https://twitter.com/reactconfbr) - [Facebook](https://www.facebook.com/reactconf/)
 
 ### ReactJS Day 2017 {/*reactjs-day-2017*/}
 October 6 in Verona, Italy
 
-[Website](http://2017.reactjsday.it) - [Twitter](https://twitter.com/reactjsday) - [Videos](https://www.youtube.com/watch?v=bUqqJPIgjNU&list=PLWK9j6ps_unl293VhhN4RYMCISxye3xH9)
+[Site web](http://2017.reactjsday.it) - [Twitter](https://twitter.com/reactjsday) - [Vidéos](https://www.youtube.com/watch?v=bUqqJPIgjNU&list=PLWK9j6ps_unl293VhhN4RYMCISxye3xH9)
 
 ### React Alicante 2017 {/*react-alicante-2017*/}
 September 28-30 in Alicante, Spain
 
-[Website](http://reactalicante.es) - [Twitter](https://twitter.com/ReactAlicante) - [Videos](https://www.youtube.com/watch?v=UMZvRCWo6Dw&list=PLd7nkr8mN0sWvBH_s0foCE6eZTX8BmLUM)
+[Site web](http://reactalicante.es) - [Twitter](https://twitter.com/ReactAlicante) - [Vidéos](https://www.youtube.com/watch?v=UMZvRCWo6Dw&list=PLd7nkr8mN0sWvBH_s0foCE6eZTX8BmLUM)
 
 ### React Boston 2017 {/*react-boston-2017*/}
 September 23-24 in Boston, Massachusetts USA
 
-[Website](http://www.reactboston.com/) - [Twitter](https://twitter.com/ReactBoston) - [Videos](https://www.youtube.com/watch?v=2iPE5l3cl_s&list=PL-fCkV3wv4ub8zJMIhmrrLcQqSR5XPlIT)
+[Site web](http://www.reactboston.com/) - [Twitter](https://twitter.com/ReactBoston) - [Vidéos](https://www.youtube.com/watch?v=2iPE5l3cl_s&list=PL-fCkV3wv4ub8zJMIhmrrLcQqSR5XPlIT)
 
 ### ReactFoo 2017 {/*reactfoo-2017*/}
 September 14 in Bangalore, India
 
-[Website](https://reactfoo.in/2017/) - [Videos](https://www.youtube.com/watch?v=3G6tMg29Wnw&list=PL279M8GbNsespKKm1L0NAzYLO6gU5LvfH)
+[Site web](https://reactfoo.in/2017/) - [Vidéos](https://www.youtube.com/watch?v=3G6tMg29Wnw&list=PL279M8GbNsespKKm1L0NAzYLO6gU5LvfH)
 
 ### ReactNext 2017 {/*reactnext-2017*/}
 September 8-10 in Tel Aviv, Israel
 
-[Website](http://react-next.com/) - [Twitter](https://twitter.com/ReactNext) - [Videos (Hall A)](https://www.youtube.com/watch?v=eKXQw5kR86c&list=PLMYVq3z1QxSqq6D7jxVdqttOX7H_Brq8Z), [Videos (Hall B)](https://www.youtube.com/watch?v=1InokWxYGnE&list=PLMYVq3z1QxSqCZmaqgTXLsrcJ8mZmBF7T)
+[Site web](http://react-next.com/) - [Twitter](https://twitter.com/ReactNext) - [Videos (Hall A)](https://www.youtube.com/watch?v=eKXQw5kR86c&list=PLMYVq3z1QxSqq6D7jxVdqttOX7H_Brq8Z), [Videos (Hall B)](https://www.youtube.com/watch?v=1InokWxYGnE&list=PLMYVq3z1QxSqCZmaqgTXLsrcJ8mZmBF7T)
 
 ### React Native EU 2017 {/*react-native-eu-2017*/}
 September 6-7 in Wroclaw, Poland
 
-[Website](http://react-native.eu/) - [Videos](https://www.youtube.com/watch?v=453oKJAqfy0&list=PLzUKC1ci01h_hkn7_KoFA-Au0DXLAQZR7)
+[Site web](http://react-native.eu/) - [Vidéos](https://www.youtube.com/watch?v=453oKJAqfy0&list=PLzUKC1ci01h_hkn7_KoFA-Au0DXLAQZR7)
 
 ### React Rally 2017 {/*react-rally-2017*/}
 August 24-25 in Salt Lake City, Utah USA
 
-[Website](http://www.reactrally.com) - [Twitter](https://twitter.com/reactrally) - [Videos](https://www.youtube.com/watch?v=f4KnHNCZcH4&list=PLUD4kD-wL_zZUhvAIHJjueJDPr6qHvkni)
+[Site web](http://www.reactrally.com) - [Twitter](https://twitter.com/reactrally) - [Vidéos](https://www.youtube.com/watch?v=f4KnHNCZcH4&list=PLUD4kD-wL_zZUhvAIHJjueJDPr6qHvkni)
 
 ### Chain React 2017 {/*chain-react-2017*/}
 July 10-11 in Portland, Oregon USA
 
-[Website](https://infinite.red/ChainReactConf) - [Twitter](https://twitter.com/chainreactconf) - [Videos](https://www.youtube.com/watch?v=cz5BzwgATpc&list=PLFHvL21g9bk3RxJ1Ut5nR_uTZFVOxu522)
+[Site web](https://infinite.red/ChainReactConf) - [Twitter](https://twitter.com/chainreactconf) - [Vidéos](https://www.youtube.com/watch?v=cz5BzwgATpc&list=PLFHvL21g9bk3RxJ1Ut5nR_uTZFVOxu522)
 
 ### ReactEurope 2017 {/*reacteurope-2017*/}
 May 18th & 19th in Paris, France
 
-[Videos](https://www.youtube.com/c/ReacteuropeOrgConf)
+[Vidéos](https://www.youtube.com/c/ReacteuropeOrgConf)
 
 ### React Amsterdam 2017 {/*react-amsterdam-2017*/}
 April 21st in Amsterdam, The Netherlands
 
-[Website](https://reactsummit.com) - [Twitter](https://twitter.com/reactsummit) - [Videos](https://youtube.com/c/ReactConferences)
+[Site web](https://reactsummit.com) - [Twitter](https://twitter.com/reactsummit) - [Vidéos](https://youtube.com/c/ReactConferences)
 
 ### React London 2017 {/*react-london-2017*/}
 March 28th at the [QEII Centre, London](http://qeiicentre.london/)
 
-[Website](http://react.london/) - [Videos](https://www.youtube.com/watch?v=2j9rSur_mnk&list=PLW6ORi0XZU0CFjdoYeC0f5QReBG-NeNKJ)
+[Site web](http://react.london/) - [Vidéos](https://www.youtube.com/watch?v=2j9rSur_mnk&list=PLW6ORi0XZU0CFjdoYeC0f5QReBG-NeNKJ)
 
 ### React Conf 2017 {/*react-conf-2017*/}
 March 13-14 in Santa Clara, CA
 
-[Website](http://conf.reactjs.org/) - [Videos](https://www.youtube.com/watch?v=7HSd1sk07uU&list=PLb0IAmt7-GS3fZ46IGFirdqKTIxlws7e0)
+[Site web](http://conf.reactjs.org/) - [Vidéos](https://www.youtube.com/watch?v=7HSd1sk07uU&list=PLb0IAmt7-GS3fZ46IGFirdqKTIxlws7e0)
 
 ### Agent Conference 2017 {/*agent-conference-2017*/}
 January 20-21 in Dornbirn, Austria
 
-[Website](http://agent.sh/)
+[Site web](http://agent.sh/)
 
 ### React Remote Conf 2016 {/*react-remote-conf-2016*/}
 October 26-28 online
 
-[Website](https://allremoteconfs.com/react-2016) - [Schedule](https://allremoteconfs.com/react-2016#schedule)
+[Site web](https://allremoteconfs.com/react-2016) - [Schedule](https://allremoteconfs.com/react-2016#schedule)
 
 ### Reactive 2016 {/*reactive-2016*/}
 October 26-28 in Bratislava, Slovakia
 
-[Website](https://reactiveconf.com/)
+[Site web](https://reactiveconf.com/)
 
 ### ReactNL 2016 {/*reactnl-2016*/}
 October 13 in Amsterdam, The Netherlands
 
-[Website](http://reactnl.org/) - [Schedule](http://reactnl.org/#program)
+[Site web](http://reactnl.org/) - [Schedule](http://reactnl.org/#program)
 
 ### ReactNext 2016 {/*reactnext-2016*/}
 September 15 in Tel Aviv, Israel
 
-[Website](http://react-next.com/) - [Schedule](http://react-next.com/#schedule) - [Videos](https://www.youtube.com/channel/UC3BT8hh3yTTYxbLQy_wbk2w)
+[Site web](http://react-next.com/) - [Schedule](http://react-next.com/#schedule) - [Vidéos](https://www.youtube.com/channel/UC3BT8hh3yTTYxbLQy_wbk2w)
 
 ### ReactRally 2016 {/*reactrally-2016*/}
 August 25-26 in Salt Lake City, UT
 
-[Website](http://www.reactrally.com/) - [Schedule](http://www.reactrally.com/#/schedule) - [Videos](https://www.youtube.com/playlist?list=PLUD4kD-wL_zYSfU3tIYsb4WqfFQzO_EjQ)
+[Site web](http://www.reactrally.com/) - [Schedule](http://www.reactrally.com/#/schedule) - [Vidéos](https://www.youtube.com/playlist?list=PLUD4kD-wL_zYSfU3tIYsb4WqfFQzO_EjQ)
 
 ### ReactEurope 2016 {/*reacteurope-2016*/}
 June 2 & 3 in Paris, France
 
-[Videos](https://www.youtube.com/c/ReacteuropeOrgConf)
+[Vidéos](https://www.youtube.com/c/ReacteuropeOrgConf)
 
 ### React Amsterdam 2016 {/*react-amsterdam-2016*/}
 April 16 in Amsterdam, The Netherlands
 
-[Website](https://reactsummit.com) - [Twitter](https://twitter.com/reactsummit) - [Facebook](https://www.facebook.com/reactamsterdam) - [Videos](https://youtube.com/c/ReactConferences)
+[Site web](https://reactsummit.com) - [Twitter](https://twitter.com/reactsummit) - [Facebook](https://www.facebook.com/reactamsterdam) - [Vidéos](https://youtube.com/c/ReactConferences)
 
 ### React.js Conf 2016 {/*reactjs-conf-2016*/}
 February 22 & 23 in San Francisco, CA
 
-[Website](http://conf2016.reactjs.org/) - [Schedule](http://conf2016.reactjs.org/schedule.html) - [Videos](https://www.youtube.com/playlist?list=PLb0IAmt7-GS0M8Q95RIc2lOM6nc77q1IY)
+[Site web](http://conf2016.reactjs.org/) - [Schedule](http://conf2016.reactjs.org/schedule.html) - [Vidéos](https://www.youtube.com/playlist?list=PLb0IAmt7-GS0M8Q95RIc2lOM6nc77q1IY)
 
 ### Reactive 2015 {/*reactive-2015*/}
 November 2-4 in Bratislava, Slovakia
 
-[Website](https://reactive2015.com/) - [Schedule](https://reactive2015.com/schedule_speakers.html#schedule)
+[Site web](https://reactive2015.com/) - [Schedule](https://reactive2015.com/schedule_speakers.html#schedule)
 
 ### ReactEurope 2015 {/*reacteurope-2015*/}
 July 2 & 3 in Paris, France
 
-[Videos](https://www.youtube.com/c/ReacteuropeOrgConf)
+[Vidéos](https://www.youtube.com/c/ReacteuropeOrgConf)
 
 ### React.js Conf 2015 {/*reactjs-conf-2015*/}
 January 28 & 29 in Facebook HQ, CA
 
-[Website](http://conf2015.reactjs.org/) - [Schedule](http://conf2015.reactjs.org/schedule.html) - [Videos](https://www.youtube.com/playlist?list=PLb0IAmt7-GS1cbw4qonlQztYV1TAW0sCr)
+[Site web](http://conf2015.reactjs.org/) - [Schedule](http://conf2015.reactjs.org/schedule.html) - [Vidéos](https://www.youtube.com/playlist?list=PLb0IAmt7-GS1cbw4qonlQztYV1TAW0sCr)

--- a/src/content/community/docs-contributors.md
+++ b/src/content/community/docs-contributors.md
@@ -1,42 +1,48 @@
 ---
-title: Docs Contributors
+title: Contributeurs aux docs
 ---
 
 <Intro>
 
-React documentation is written and maintained by the [React team](/community/team) and [external contributors.](https://github.com/reactjs/reactjs.org/graphs/contributors) On this page, we'd like to thank a few people who've made significant contributions to this site.
+La documentation de React est écrite et maintenue par [l'équipe React](/community/team) et des [contributeurs externes](https://github.com/reactjs/react.dev/graphs/contributors). Sur cette page, nous aimerions remercier les personnes qui ont significativement contribué à ce site.
 
 </Intro>
 
-## Content {/*content*/}
+## Contenu {/*content*/}
 
-* [Rachel Nabors](https://twitter.com/RachelNabors): editing, writing, illustrating
-* [Dan Abramov](https://twitter.com/dan_abramov): writing, curriculum design
-* [Sylwia Vargas](https://twitter.com/SylwiaVargas): example code
-* [Rick Hanlon](https://twitter.com/rickhanlonii): writing
-* [David McCabe](https://twitter.com/mcc_abe): writing
-* [Sophie Alpert](https://twitter.com/sophiebits): writing
-* [Pete Hunt](https://twitter.com/floydophone): writing
-* [Andrew Clark](https://twitter.com/acdlite): writing
-* [Matt Carroll](https://twitter.com/mattcarrollcode): editing, writing
-* [Natalia Tepluhina](https://twitter.com/n_tepluhina): reviews, advice
-* [Sebastian Markbåge](https://twitter.com/sebmarkbage): feedback
+* [Rachel Nabors](https://twitter.com/RachelNabors) : révisions, rédaction, illustrations
+* [Dan Abramov](https://twitter.com/dan_abramov) : rédaction, conception du curriculum
+* [Sylwia Vargas](https://twitter.com/SylwiaVargas) : codes d'exemple
+* [Rick Hanlon](https://twitter.com/rickhanlonii) : rédaction
+* [David McCabe](https://twitter.com/mcc_abe) : rédaction
+* [Sophie Alpert](https://twitter.com/sophiebits) : rédaction
+* [Pete Hunt](https://twitter.com/floydophone) : rédaction
+* [Andrew Clark](https://twitter.com/acdlite) : rédaction
+* [Matt Carroll](https://twitter.com/mattcarrollcode) : révisions, rédaction
+* [Natalia Tepluhina](https://twitter.com/n_tepluhina) : révisions, avis
+* [Sebastian Markbåge](https://twitter.com/sebmarkbage) : retours
 
 ## Design {/*design*/}
 
-* [Dan Lebowitz](https://twitter.com/lebo): site design
-* [Razvan Gradinar](https://dribbble.com/GradinarRazvan): sandbox design
-* [Maggie Appleton](https://maggieappleton.com/): diagram system
-* [Sophie Alpert](https://twitter.com/sophiebits): color-coded explanations
+* [Dan Lebowitz](https://twitter.com/lebo) : design du site
+* [Razvan Gradinar](https://dribbble.com/GradinarRazvan) : design des bacs à sable
+* [Maggie Appleton](https://maggieappleton.com/) : système de diagrammes
+* [Sophie Alpert](https://twitter.com/sophiebits) : codage par couleurs des explications
 
-## Development {/*development*/}
+## Développement {/*development*/}
 
-* [Jared Palmer](https://twitter.com/jaredpalmer): site development
-* [ThisDotLabs](https://www.thisdot.co/) ([Dane Grant](https://twitter.com/danecando), [Dustin Goodman](https://twitter.com/dustinsgoodman)): site development
-* [CodeSandbox](https://codesandbox.io/) ([Ives van Hoorne](https://twitter.com/CompuIves), [Alex Moldovan](https://twitter.com/alexnmoldovan), [Jasper De Moor](https://twitter.com/JasperDeMoor), [Danilo Woznica](https://twitter.com/danilowoz)): sandbox integration
-* [Dan Abramov](https://twitter.com/dan_abramov): site development
-* [Rick Hanlon](https://twitter.com/rickhanlonii): site development
-* [Harish Kumar](https://www.strek.in/): development and maintenance
-* [Luna Ruan](https://twitter.com/lunaruan): sandbox improvements
+* [Jared Palmer](https://twitter.com/jaredpalmer) : développement du site
+* [ThisDotLabs](https://www.thisdot.co/) ([Dane Grant](https://twitter.com/danecando) et [Dustin Goodman](https://twitter.com/dustinsgoodman)) : développement du site
+* [CodeSandbox](https://codesandbox.io/) ([Ives van Hoorne](https://twitter.com/CompuIves), [Alex Moldovan](https://twitter.com/alexnmoldovan), [Jasper De Moor](https://twitter.com/JasperDeMoor) et [Danilo Woznica](https://twitter.com/danilowoz)) : intégration des bacs à sable
+* [Dan Abramov](https://twitter.com/dan_abramov) : développement du site
+* [Rick Hanlon](https://twitter.com/rickhanlonii) : développement du site
+* [Harish Kumar](https://www.strek.in/) : development et maintenance
+* [Luna Ruan](https://twitter.com/lunaruan) : améliorations des bacs à sable
 
-We'd also like to thank countless alpha testers and community members who gave us feedback along the way.
+Nous aimerions aussi remercier les innombrables testeurs de la première heure et membres de la communautés qui nous ont fourni des retours tout au long de notre travail.
+
+## Traduction {/*translation*/}
+
+Si vous bénéficiez d’une traduction française de qualité et à jour de la documentation officielle React, c’est grâce au travail bénévole d’un nombre significatif de traducteur·rice·s, qui dans certains cas ont fait là leur premier travail de traduction, voire leur première contribution sur GitHub.
+
+[Christophe Porteneuve](https://twitter.com/porteneuve) pilote l’effort de traduction française ; vous pourrez trouver tout le détail des personnes ayant contribué à la traduction et de leurs travaux respectifs dans [ce document](https://github.com/reactjs/fr.react.dev/blob/main/TRANSLATORS.md). Mille merci à elles !

--- a/src/content/community/index.md
+++ b/src/content/community/index.md
@@ -1,14 +1,14 @@
 ---
-title: React Community
+title: Communauté React
 ---
 
 <Intro>
 
-La communauté React compte des millions de développeur·se·s. Sur cette page, nous avons répertorié certaines communautés liées à React auxquelles vous pouvez participer ; reportez-vous aux autres pages de cette section pour obtenir d'autres ressources en personne ou en ligne.
+La communauté React compte des millions de développeur·se·s. Sur cette page, nous avons répertorié certaines communautés liées à React auxquelles vous pouvez participer ; consultez les autres pages de cette section pour obtenir d'autres ressources en personne ou en ligne.
 
 </Intro>
 
-## Code of Conduct {/*code-of-conduct*/}
+## Code de Conduite {/*code-of-conduct*/}
 
 Avant de participer aux communautés React, [merci de lire notre Code de Conduite](https://github.com/facebook/react/blob/master/CODE_OF_CONDUCT.md). Nous avons adopté le [Contributor Covenant](https://www.contributor-covenant.org/) et attendons de tous les membres de nos communautés qu’ils·elles respectent les règles et recommandations qui y figurent.
 

--- a/src/content/community/meetups.md
+++ b/src/content/community/meetups.md
@@ -1,32 +1,46 @@
 ---
-title: React Meetups
+title: Meetups React
 ---
 
 <Intro>
 
-Do you have a local React.js meetup? Add it here! (Please keep the list alphabetical)
+Vous connaissez un meetup React.js local ? Ajoutez-le ! (Merci de conserver un ordre alphabétique de pays et dans chaque pays.)
 
 </Intro>
 
-## Albania {/*albania*/}
+## Albanie {/*albania*/}
 * [Tirana](https://www.meetup.com/React-User-Group-Albania/)
 
-## Argentina {/*argentina*/}
+## Allemagne {/*germany*/}
+* [Cologne](https://www.meetup.com/React-Cologne/)
+* [Düsseldorf](https://www.meetup.com/de-DE/ReactJS-Meetup-Dusseldorf/)
+* [Hamburg](https://www.meetup.com/Hamburg-React-js-Meetup/)
+* [Karlsruhe](https://www.meetup.com/react_ka/)
+* [Kiel](https://www.meetup.com/Kiel-React-Native-Meetup/)
+* [Munich](https://www.meetup.com/ReactJS-Meetup-Munich/)
+* [React Berlin](https://www.meetup.com/React-Open-Source/)
+
+## Angleterre (R.-U.) {/*england-uk*/}
+* [Manchester](https://www.meetup.com/Manchester-React-User-Group/)
+* [React.JS Girls London](https://www.meetup.com/ReactJS-Girls-London/)
+* [React London : Bring Your Own Project](https://www.meetup.com/React-London-Bring-Your-Own-Project/)
+
+## Argentine {/*argentina*/}
 * [Buenos Aires](https://www.meetup.com/es/React-en-Buenos-Aires)
 * [Rosario](https://www.meetup.com/es/reactrosario)
 
-## Australia {/*australia*/}
+## Australie {/*australia*/}
 * [Brisbane](https://www.meetup.com/reactbris/)
 * [Melbourne](https://www.meetup.com/React-Melbourne/)
 * [Sydney](https://www.meetup.com/React-Sydney/)
 
-## Austria {/*austria*/}
+## Autriche {/*austria*/}
 * [Vienna](https://www.meetup.com/Vienna-ReactJS-Meetup/)
 
-## Belgium {/*belgium*/}
+## Belgique {/*belgium*/}
 * [Belgium](https://www.meetup.com/ReactJS-Belgium/)
 
-## Brazil {/*brazil*/}
+## Brésil {/*brazil*/}
 * [Belo Horizonte](https://www.meetup.com/reactbh/)
 * [Curitiba](https://www.meetup.com/pt-br/ReactJS-CWB/)
 * [Florianópolis](https://www.meetup.com/pt-br/ReactJS-Floripa/)
@@ -40,7 +54,7 @@ Do you have a local React.js meetup? Add it here! (Please keep the list alphabet
 * [São Paulo](https://www.meetup.com/pt-BR/ReactJS-SP/)
 * [Vila Velha](https://www.meetup.com/pt-BR/React-ES/)
 
-## Bolivia {/*bolivia*/}
+## Bolivie {/*bolivia*/}
 * [Bolivia](https://www.meetup.com/ReactBolivia/)
 
 ## Canada {/*canada*/}
@@ -50,131 +64,32 @@ Do you have a local React.js meetup? Add it here! (Please keep the list alphabet
 * [Ottawa, ON](https://www.meetup.com/Ottawa-ReactJS-Meetup/)
 * [Toronto, ON](https://www.meetup.com/Toronto-React-Native/events/)
 
-## Chile {/*chile*/}
+## Chili {/*chile*/}
 * [Santiago](https://www.meetup.com/es-ES/react-santiago/)
 
-## China {/*china*/}
+## Chine {/*china*/}
 * [Beijing](https://www.meetup.com/Beijing-ReactJS-Meetup/)
 
-## Colombia {/*colombia*/}
+## Colombie {/*colombia*/}
 * [Bogotá](https://www.meetup.com/meetup-group-iHIeHykY/)
 * [Medellin](https://www.meetup.com/React-Medellin/)
 * [Cali](https://www.meetup.com/reactcali/)
 
-## Denmark {/*denmark*/}
+## Danemark {/*denmark*/}
 * [Aalborg](https://www.meetup.com/Aalborg-React-React-Native-Meetup/)
 * [Aarhus](https://www.meetup.com/Aarhus-ReactJS-Meetup/)
 
-## Egypt {/*egypt*/}
-* [Cairo](https://www.meetup.com/react-cairo/)
-
-## England (UK) {/*england-uk*/}
-* [Manchester](https://www.meetup.com/Manchester-React-User-Group/)
-* [React.JS Girls London](https://www.meetup.com/ReactJS-Girls-London/)
-* [React London : Bring Your Own Project](https://www.meetup.com/React-London-Bring-Your-Own-Project/)
-
-## France {/*france*/}
-* [Nantes](https://www.meetup.com/React-Nantes/)
-* [Lille](https://www.meetup.com/ReactBeerLille/)
-* [Paris](https://www.meetup.com/ReactJS-Paris/)
-
-## Germany {/*germany*/}
-* [Cologne](https://www.meetup.com/React-Cologne/)
-* [Düsseldorf](https://www.meetup.com/de-DE/ReactJS-Meetup-Dusseldorf/)
-* [Hamburg](https://www.meetup.com/Hamburg-React-js-Meetup/)
-* [Karlsruhe](https://www.meetup.com/react_ka/)
-* [Kiel](https://www.meetup.com/Kiel-React-Native-Meetup/)
-* [Munich](https://www.meetup.com/ReactJS-Meetup-Munich/)
-* [React Berlin](https://www.meetup.com/React-Open-Source/)
-
-## Greece {/*greece*/}
-* [Athens](https://www.meetup.com/React-To-React-Athens-MeetUp/)
-* [Thessaloniki](https://www.meetup.com/Thessaloniki-ReactJS-Meetup/)
-
-## Hungary {/*hungary*/}
-* [Budapest](https://www.meetup.com/React-Budapest/)
-
-## India {/*india*/}
-* [Ahmedabad](https://www.meetup.com/react-ahmedabad/)
-* [Bangalore](https://www.meetup.com/ReactJS-Bangalore/)
-* [Bangalore](https://www.meetup.com/React-Native-Bangalore-Meetup)
-* [Chandigarh](https://www.meetup.com/Chandigarh-React-Developers/)
-* [Chennai](https://www.meetup.com/React-Chennai/)
-* [Delhi NCR](https://www.meetup.com/React-Delhi-NCR/)
-* [Jaipur](https://www.meetup.com/JaipurJS-Developer-Meetup/)
-* [Pune](https://www.meetup.com/ReactJS-and-Friends/)
-
-## Indonesia {/*indonesia*/}
-* [Indonesia](https://www.meetup.com/reactindonesia/)
-
-## Ireland {/*ireland*/}
-* [Dublin](https://www.meetup.com/ReactJS-Dublin/)
-
-## Israel {/*israel*/}
-* [Tel Aviv](https://www.meetup.com/ReactJS-Israel/)
-
-## Italy {/*italy*/}
-* [Milan](https://www.meetup.com/React-JS-Milano/)
-
-## Kenya {/*kenya*/}
-* [Nairobi - Reactdevske](https://kommunity.com/reactjs-developer-community-kenya-reactdevske)
-
-## Malaysia {/*malaysia*/}
-* [Kuala Lumpur](https://www.kl-react.com/)
-* [Penang](https://www.facebook.com/groups/reactpenang/)
-
-## Netherlands {/*netherlands*/}
-* [Amsterdam](https://www.meetup.com/React-Amsterdam/)
-
-## New Zealand {/*new-zealand*/}
-* [Wellington](https://www.meetup.com/React-Wellington/)
-
-## Norway {/*norway*/}
-* [Norway](https://reactjs-norway.webflow.io/)
-* [Oslo](https://www.meetup.com/ReactJS-Oslo-Meetup/)
-
-## Pakistan {/*pakistan*/}
-* [Karachi](https://www.facebook.com/groups/902678696597634/)
-* [Lahore](https://www.facebook.com/groups/ReactjsLahore/)
-
-## Panama {/*panama*/}
-* [Panama](https://www.meetup.com/React-Panama/)
-
-## Peru {/*peru*/}
-* [Lima](https://www.meetup.com/ReactJS-Peru/)
-
-## Philippines {/*philippines*/}
-* [Manila](https://www.meetup.com/reactjs-developers-manila/)
-* [Manila - ReactJS PH](https://www.meetup.com/ReactJS-Philippines/)
-
-## Poland {/*poland*/}
-* [Warsaw](https://www.meetup.com/React-js-Warsaw/)
-* [Wrocław](https://www.meetup.com/ReactJS-Wroclaw/)
-
-## Portugal {/*portugal*/}
-* [Lisbon](https://www.meetup.com/JavaScript-Lisbon/)
-
-## Scotland (UK) {/*scotland-uk*/}
+## Écosse (R.-U.) {/*scotland-uk*/}
 * [Edinburgh](https://www.meetup.com/React-Scotland/)
 
-## Spain {/*spain*/}
+## Égypte {/*egypt*/}
+* [Cairo](https://www.meetup.com/react-cairo/)
+
+## Espagne {/*spain*/}
 * [Barcelona](https://www.meetup.com/ReactJS-Barcelona/)
 * [Canarias](https://www.meetup.com/React-Canarias/)
 
-## Sweden {/*sweden*/}
-* [Goteborg](https://www.meetup.com/ReactJS-Goteborg/)
-* [Stockholm](https://www.meetup.com/Stockholm-ReactJS-Meetup/)
-
-## Switzerland {/*switzerland*/}
-* [Zurich](https://www.meetup.com/Zurich-ReactJS-Meetup/)
-
-## Turkey {/*turkey*/}
-* [Istanbul](https://kommunity.com/reactjs-istanbul)
-
-## Ukraine {/*ukraine*/}
-* [Kyiv](https://www.meetup.com/Kyiv-ReactJS-Meetup)
-
-## US {/*us*/}
+## États-Unis {/*us*/}
 * [Ann Arbor, MI - ReactJS](https://www.meetup.com/AnnArbor-jsx/)
 * [Atlanta, GA - ReactJS](https://www.meetup.com/React-ATL/)
 * [Austin, TX - ReactJS](https://www.meetup.com/ReactJS-Austin-Meetup/)
@@ -220,3 +135,88 @@ Do you have a local React.js meetup? Add it here! (Please keep the list alphabet
 * [Tampa, FL - ReactJS](https://www.meetup.com/ReactJS-Tampa-Bay/)
 * [Tucson, AZ - ReactJS](https://www.meetup.com/Tucson-ReactJS-Meetup/)
 * [Washington, DC - ReactJS](https://www.meetup.com/React-DC/)
+
+## France {/*france*/}
+* [Nantes](https://www.meetup.com/React-Nantes/)
+* [Lille](https://www.meetup.com/ReactBeerLille/)
+* [Paris](https://www.meetup.com/ReactJS-Paris/)
+
+## Grèce {/*greece*/}
+* [Athens](https://www.meetup.com/React-To-React-Athens-MeetUp/)
+* [Thessaloniki](https://www.meetup.com/Thessaloniki-ReactJS-Meetup/)
+
+## Hongrie {/*hungary*/}
+* [Budapest](https://www.meetup.com/React-Budapest/)
+
+## Inde {/*india*/}
+* [Ahmedabad](https://www.meetup.com/react-ahmedabad/)
+* [Bangalore](https://www.meetup.com/ReactJS-Bangalore/)
+* [Bangalore](https://www.meetup.com/React-Native-Bangalore-Meetup)
+* [Chandigarh](https://www.meetup.com/Chandigarh-React-Developers/)
+* [Chennai](https://www.meetup.com/React-Chennai/)
+* [Delhi NCR](https://www.meetup.com/React-Delhi-NCR/)
+* [Jaipur](https://www.meetup.com/JaipurJS-Developer-Meetup/)
+* [Pune](https://www.meetup.com/ReactJS-and-Friends/)
+
+## Indonésie {/*indonesia*/}
+* [Indonesia](https://www.meetup.com/reactindonesia/)
+
+## Irlande {/*ireland*/}
+* [Dublin](https://www.meetup.com/ReactJS-Dublin/)
+
+## Israël {/*israel*/}
+* [Tel Aviv](https://www.meetup.com/ReactJS-Israel/)
+
+## Italie {/*italy*/}
+* [Milan](https://www.meetup.com/React-JS-Milano/)
+
+## Kenya {/*kenya*/}
+* [Nairobi - Reactdevske](https://kommunity.com/reactjs-developer-community-kenya-reactdevske)
+
+## Malaisie {/*malaysia*/}
+* [Kuala Lumpur](https://www.kl-react.com/)
+* [Penang](https://www.facebook.com/groups/reactpenang/)
+
+## Nouvelle-Zélande {/*new-zealand*/}
+* [Wellington](https://www.meetup.com/React-Wellington/)
+
+## Norvège {/*norway*/}
+* [Norway](https://reactjs-norway.webflow.io/)
+* [Oslo](https://www.meetup.com/ReactJS-Oslo-Meetup/)
+
+## Pakistan {/*pakistan*/}
+* [Karachi](https://www.facebook.com/groups/902678696597634/)
+* [Lahore](https://www.facebook.com/groups/ReactjsLahore/)
+
+## Panama {/*panama*/}
+* [Panama](https://www.meetup.com/React-Panama/)
+
+## Pays-Bas {/*netherlands*/}
+* [Amsterdam](https://www.meetup.com/React-Amsterdam/)
+
+## Pérou {/*peru*/}
+* [Lima](https://www.meetup.com/ReactJS-Peru/)
+
+## Philippines {/*philippines*/}
+* [Manila](https://www.meetup.com/reactjs-developers-manila/)
+* [Manila - ReactJS PH](https://www.meetup.com/ReactJS-Philippines/)
+
+## Pologne {/*poland*/}
+* [Warsaw](https://www.meetup.com/React-js-Warsaw/)
+* [Wrocław](https://www.meetup.com/ReactJS-Wroclaw/)
+
+## Portugal {/*portugal*/}
+* [Lisbon](https://www.meetup.com/JavaScript-Lisbon/)
+
+## Suède {/*sweden*/}
+* [Goteborg](https://www.meetup.com/ReactJS-Goteborg/)
+* [Stockholm](https://www.meetup.com/Stockholm-ReactJS-Meetup/)
+
+## Suisse {/*switzerland*/}
+* [Zurich](https://www.meetup.com/Zurich-ReactJS-Meetup/)
+
+## Turquie {/*turkey*/}
+* [Istanbul](https://kommunity.com/reactjs-istanbul)
+
+## Ukraine {/*ukraine*/}
+* [Kyiv](https://www.meetup.com/Kyiv-ReactJS-Meetup)

--- a/src/content/community/team.md
+++ b/src/content/community/team.md
@@ -1,18 +1,18 @@
 ---
-title: "Meet the Team"
+title: Rencontrez l’équipe
 ---
 
 <Intro>
 
-React development is led by a dedicated team working full time at Meta. It also receives contributions from people all over the world.
+Le développement de React est piloté par une équipe dédiée travaillant à temps plein chez Meta.  Il reçoit également des contributions par des personnes du monde entier.
 
 </Intro>
 
-## React Core {/*react-core*/}
+## Équipe noyau (React Core) {/*react-core*/}
 
-The React Core team members work full time on the core component APIs, the engine that powers React DOM and React Native, React DevTools, and the React documentation website.
+Les membres de l'équipe noyau travaillent à temps plein sur les API de composants noyaux, le moteur qui propulse React DOM et React Native, les outils de développement React le site de la documentation de React.
 
-Current members of the React team are listed in alphabetical order below.
+Les membres actuels de l'équipe React sont listés ci-dessous par ordre alphabétique.
 
 <TeamMember name="Andrew Clark" permalink="andrew-clark" photo="/images/team/acdlite.jpg" github="acdlite" twitter="acdlite" title="Engineer at Vercel">
     Andrew got started with web development by making sites with WordPress, and eventually tricked himself into doing JavaScript. His favorite pastime is karaoke. Andrew is either a Disney villain or a Disney princess, depending on the day.
@@ -27,7 +27,7 @@ Current members of the React team are listed in alphabetical order below.
 </TeamMember>
 
 <TeamMember name="Dave McCabe" permalink="dave-mccabe" photo="/images/team/dave-mccabe.jpg" github="davidmccabe" twitter="mcc_abe" title="Engineer at Meta">
-    An engineer by trade and outdoorsman at heart, David has long been an innovator in the field of programming-while-sunbathing. Besides surprising his colleagues with unique outdoor video-call backgrounds, he enjoys playing guitar (in sunlit meadows, of course) and martial arts (still indoors, gotta work on that). 
+    An engineer by trade and outdoorsman at heart, David has long been an innovator in the field of programming-while-sunbathing. Besides surprising his colleagues with unique outdoor video-call backgrounds, he enjoys playing guitar (in sunlit meadows, of course) and martial arts (still indoors, gotta work on that).
 </TeamMember>
 
 <TeamMember name="Eli White" permalink="eli-white" photo="/images/team/eli-white.jpg" github="TheSavior" twitter="Eli_White" title="Engineering Manager at Meta">
@@ -59,7 +59,7 @@ Current members of the React team are listed in alphabetical order below.
 </TeamMember>
 
 <TeamMember name="Luna Wei" permalink="luna-wei" photo="/images/team/luna-wei.jpg" github="lunaleaps" twitter="lunaleaps" title="Engineer at Meta">
-    Luna first learnt the fundamentals of python at the age of 6 from her father. Since then, she has been unstoppable. Luna aspires to be a gen z, and the road to success is paved with environmental advocacy, urban gardening and lots of quality time with her Voo-Doo’d (as pictured). 
+    Luna first learnt the fundamentals of python at the age of 6 from her father. Since then, she has been unstoppable. Luna aspires to be a gen z, and the road to success is paved with environmental advocacy, urban gardening and lots of quality time with her Voo-Doo’d (as pictured).
 </TeamMember>
 
 <TeamMember name="Matt Carroll" permalink="matt-carroll" photo="/images/team/matt-carroll.png" github="mattcarrollcode" twitter="mattcarrollcode" title="Developer Advocate at Meta">
@@ -114,6 +114,6 @@ Current members of the React team are listed in alphabetical order below.
     Yuzhi studied Computer Science in school. She liked the instant gratification of seeing code come to life without having to physically be in a laboratory. Now she’s a manager in the React org. Before management, she used to work on the Relay data fetching framework. In her spare time, Yuzhi enjoys optimizing her life via gardening and home improvement projects.
 </TeamMember>
 
-## Past contributors {/*past-contributors*/}
+## Contributeurs historiques {/*past-contributors*/}
 
-You can find the past team members and other people who significantly contributed to React over the years on the [acknowledgements](/community/acknowledgements) page.
+Vous trouverez une liste des membres passés de l'équipe et d'autres personnes ayant significativement contribué à React au fil des ans dans la page des [remerciements](/community/acknowledgements).

--- a/src/content/community/versioning-policy.md
+++ b/src/content/community/versioning-policy.md
@@ -1,5 +1,5 @@
 ---
-title: Versioning Policy
+title: Politique de versions
 ---
 
 <Intro>

--- a/src/content/community/videos.md
+++ b/src/content/community/videos.md
@@ -1,10 +1,10 @@
 ---
-title: React Videos
+title: Vidéos React
 ---
 
 <Intro>
 
-Videos dedicated to the discussion of React and the React ecosystem.
+Des vidéos centrées sur React et son écosystème.
 
 </Intro>
 

--- a/src/sidebarCommunity.json
+++ b/src/sidebarCommunity.json
@@ -12,31 +12,31 @@
       "skipBreadcrumb": true,
       "routes": [
         {
-          "title": "React Conferences",
+          "title": "Conférences",
           "path": "/community/conferences"
         },
         {
-          "title": "React Meetups",
+          "title": "Meetups React",
           "path": "/community/meetups"
         },
         {
-          "title": "React Videos",
+          "title": "Vidéos React",
           "path": "/community/videos"
         },
         {
-          "title": "Meet the Team",
+          "title": "Rencontrez l’équipe",
           "path": "/community/team"
         },
         {
-          "title": "Docs Contributors",
+          "title": "Contributeurs aux docs",
           "path": "/community/docs-contributors"
         },
         {
-          "title": "Acknowledgements",
+          "title": "Remerciements",
           "path": "/community/acknowledgements"
         },
         {
-          "title": "Versioning Policy",
+          "title": "Politique de versions",
           "path": "/community/versioning-policy"
         }
       ]


### PR DESCRIPTION
Pretty much **all of community, except:**

- Details of conferences and meetups (dates, in-person/remote, cities, etc.)
- Descriptions of React Core team members
- Titles and descriptions of videos
- Versioning policy
- Blog posts

This smoothes up the FR experience, and does provide translation for contributors and acknowledgements, which I thought was a priority.