### PR TITLE
Chore(docs): fix typo in `Profiler` docs

### DIFF
--- a/src/content/reference/react/Profiler.md
+++ b/src/content/reference/react/Profiler.md
@@ -33,7 +33,7 @@ Enrobez un arbre de composants dans un `<Profiler>` afin de mesurer ses performa
 #### Props {/*props*/}
 
 * `id` : une chaîne de caractères identifiant la portion de l’UI que vous souhaitez mesurer.
-* `onRender` : une [fonction de rappel `onRender`](#onrender-callback) appelée à chaque nouveau rendu d’un composant situé dans l’arbre profilé. Elle reçoit des informations indiquant ce qui a fait l’objet ɗ un rendu et quel temps ça a pris.
+* `onRender` : une [fonction de rappel `onRender`](#onrender-callback) appelée à chaque nouveau rendu d’un composant situé dans l’arbre profilé. Elle reçoit des informations indiquant ce qui a fait l’objet d'un rendu et quel temps ça a pris.
 
 #### Limitations {/*caveats*/}
 


### PR DESCRIPTION
Hello @tdd  !

Je lisais la documentation sur le `Profiler` quand j'ai lu `ɗ un` dans la phrase
> Elle reçoit des informations indiquant ce qui a fait l’objet **ɗ un** rendu et quel temps ça a pris.

Je me suis dit que c'est surement une faute de frappe et que ça devrait être `d'un`. Il manquait l'apostrophe et le `ɗ` n'est pas le bon.

**Cette PR replace `ɗ un` par `d'un`.**

Issue: https://github.com/reactjs/fr.react.dev/issues/634