### PR TITLE
Chore(docs): fix typo in start a new react project docs

### DIFF
--- a/src/content/learn/start-a-new-react-project.md
+++ b/src/content/learn/start-a-new-react-project.md
@@ -81,7 +81,7 @@ Si Expo est nouveau pour vous, consultez le [tutoriel d’Expo](https://docs.exp
 
 Expo est maintenu par [Expo (la société)](https://expo.dev/about). Construire des applis avec Expo est gratuit, et vous pouvez les publier sur les plateformes Google Play et Apple Store sans restrictions. Expo propose des services cloud optionnels payants.
 
-## Frameworks Reaxt expérimentaux {/*bleeding-edge-react-frameworks*/}
+## Frameworks React expérimentaux {/*bleeding-edge-react-frameworks*/}
 
 Alors que nous cherchions comment continuer à améliorer React, nous avons réalisé que l’intégration plus étroite de React avec les frameworks (en particulier avec la gestion de routes, le *bundling* et les traitements côté serveur) constitue notre plus grande opportunité d’aider les utilisateurs de React à construire de meilleures applis. L’équipe Next.js a accepté de collaborer avec nous sur la recherche, le développement, l’intégration et les tests de fonctionnalités React de pointe, indépendantes toutefois d'un framework spécifique, comme les [Composants Serveur React](/blog/2023/03/22/react-labs-what-we-have-been-working-on-march-2023#react-server-components).
 


### PR DESCRIPTION
Hello !

Cette PR corrige une potentielle erreur de frappe dans la documentation `Créer un nouveau projet React`.
L'erreur se trouve dans le texte ci-dessous 👇 
> Frameworks *Reaxt* expérimentaux

Vous pouvez y lire `Reaxt`. Un `x` a la place du `c` en supposant que l'on souhaitait écrire React. 
Cette PR remplace par `Reaxt` par `React`.

Related issue : https://github.com/reactjs/fr.react.dev/issues/636