### PR TITLE
Fix typo on separating-events-from-effects.md

### DIFF
--- a/src/content/learn/separating-events-from-effects.md
+++ b/src/content/learn/separating-events-from-effects.md
@@ -586,7 +586,7 @@ Cette section décrit une **API expérimentale : elle n’a donc pas encore ét
 
 Les Événements d’Effets vous permettent de corriger de nombreuses situations où vous seriez tenté·e de réduire le *linter* de dépendances au silence.
 
-Par exemple, disons que vous avec un Effet qui enregistre les visites de la page :
+Par exemple, disons que vous avez un Effet qui enregistre les visites de la page :
 
 ```js
 function Page() {


### PR DESCRIPTION
This PR fixes a typo in the french version of separating-events-from-effects.md

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
